### PR TITLE
Only attach the debugbar in dev mode

### DIFF
--- a/_config/debugbar.yml
+++ b/_config/debugbar.yml
@@ -1,5 +1,7 @@
 ---
 Name: debugbar
+Only:
+  environment: 'dev'
 ---
 DebugBar:
   enable_storage:true


### PR DESCRIPTION
This prevents the debugbar to be loaded at all when not in dev mode. As another extra method to prevent unwanted loading on live sites.
