### PR TITLE
FIX Update $isTest to check whether a SapphireTest is running

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -18,7 +18,7 @@ if (!function_exists('d')) {
         $args = func_get_args();
 
         // Prevent exit in test session
-        $isTest = !empty($args) && $args[0] instanceof SapphireTest;
+        $isTest = SapphireTest::is_running_test();
 
         // Clean buffer that may be in the way
         if (!$isTest && ob_get_contents())


### PR DESCRIPTION
This removes the need to pass an instance of SapphireTest into `d()` as the first argument for it to register as being in a unit test.

On a side note, the `testDHelper` test method is not stable at the moment. It looks like the underlying symfony/var-dumper package writes to PHP memory or something similar in a way that output buffering is not capturing correctly. It will probably need to be updated.