### PR TITLE
Increase test coverage, deprecate DebugBarDatabaseProxy, add Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,34 @@
+# See https://github.com/silverstripe/silverstripe-travis-support for setup details
+
+language: php
+
+php:
+  - 5.4
+  - 5.5
+  - 5.6
+
+env:
+  - DB=MYSQL CORE_RELEASE=3.5
+
+matrix:
+  include:
+    - php: 7.1
+      env: DB=MYSQL CORE_RELEASE=3.6
+    - php: 7.1
+      env: DB=MYSQL CORE_RELEASE=3 COVERAGE="--coverage-clover=coverage.xml"
+
+before_script:
+  - composer self-update || true
+  - git clone git://github.com/silverstripe/silverstripe-travis-support.git ~/travis-support
+  - php ~/travis-support/travis_setup.php --source `pwd` --target ~/build/ss --require undefinedoffset/sortablegridfield:~0.6.9
+  - cd ~/build/ss
+
+script:
+  - vendor/bin/phpunit "$COVERAGE" debugbar/tests
+
+after_success:
+  - >
+    test "$COVERAGE" != ""
+    && mv coverage.xml ~/build/$TRAVIS_REPO_SLUG
+    && cd ~/build/$TRAVIS_REPO_SLUG
+    && bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
 before_script:
   - composer self-update || true
   - git clone git://github.com/silverstripe/silverstripe-travis-support.git ~/travis-support
-  - php ~/travis-support/travis_setup.php --source `pwd` --target ~/build/ss --require undefinedoffset/sortablegridfield:~0.6.9
+  - php ~/travis-support/travis_setup.php --source `pwd` --target ~/build/ss
   - cd ~/build/ss
 
 script:

--- a/code/DebugBar.php
+++ b/code/DebugBar.php
@@ -228,7 +228,7 @@ class DebugBar extends Object
             return 'Not in dev mode';
         }
         if (self::IsDisabled()) {
-            return 'Disabled by a constant';
+            return 'Disabled by a constant or configuration';
         }
         if (self::VendorNotInstalled()) {
             return 'DebugBar is not installed in vendors';
@@ -266,8 +266,8 @@ class DebugBar extends Object
 
     public static function IsDisabled()
     {
-        if (defined('DEBUGBAR_DISABLE')) {
-            return DEBUGBAR_DISABLE;
+        if ((defined('DEBUGBAR_DISABLE') && DEBUGBAR_DISABLE) || static::config()->disabled) {
+            return true;
         }
         return false;
     }

--- a/code/DebugBarControllerExtension.php
+++ b/code/DebugBarControllerExtension.php
@@ -14,7 +14,7 @@ class DebugBarControllerExtension extends Extension
             // We must set the current controller when it's available and before it's pushed out of stack
             $debugbar->getCollector('silverstripe')->setController(Controller::curr());
 
-            /* @var $timeData DebugBar\DataCollector\TimeDataCollector */
+            /** @var $timeData DebugBar\DataCollector\TimeDataCollector */
             $timeData = $debugbar['time'];
             if (!$timeData) {
                 return;
@@ -38,7 +38,7 @@ class DebugBarControllerExtension extends Extension
 
         DebugBar::withDebugBar(function(DebugBar\DebugBar $debugbar) use ($class) {
 
-            /* @var $timeData DebugBar\DataCollector\TimeDataCollector */
+            /** @var $timeData DebugBar\DataCollector\TimeDataCollector */
             $timeData = $debugbar['time'];
             if (!$timeData) {
                 return;

--- a/code/DebugBarDatabaseProxy.php
+++ b/code/DebugBarDatabaseProxy.php
@@ -4,6 +4,8 @@
  * A proxy database to log queries (compatible with 3.1)
  *
  * @author Koala
+ * @deprecated 1.0.0 Please upgrade to at least SilverStripe 3.2. Use DebugBarDatabaseNewProxy.
+ * @codeCoverageIgnore
  */
 class DebugBarDatabaseProxy extends SS_Database
 {

--- a/code/DebugBarSilverStripeCollector.php
+++ b/code/DebugBarSilverStripeCollector.php
@@ -112,9 +112,22 @@ class DebugBarSilverStripeCollector extends DataCollector implements Renderable,
         }
     }
 
+    /**
+     * @param Controller $controller
+     * @return $this
+     */
     public function setController($controller)
     {
         self::$controller = $controller;
+        return $this;
+    }
+
+    /**
+     * @return Controller
+     */
+    public function getController()
+    {
+        return self::$controller;
     }
 
     public function getName()

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     ],
     "require": {
         "php": ">=5.4.8",
-        "silverstripe/framework": "~3.1",
+        "silverstripe/framework": "~3.2",
+        "silverstripe/siteconfig": "~3.2",
         "maximebf/debugbar": "^1.13"
     },
     "extra": {

--- a/tests/DebugBarControllerExtensionTest.php
+++ b/tests/DebugBarControllerExtensionTest.php
@@ -1,0 +1,92 @@
+<?php
+
+class DebugBarControllerExtensionTest extends FunctionalTest
+{
+    protected $requiredExtensions = array(
+        'Controller' => array('DebugBarControllerExtension')
+    );
+
+    /**
+     * @var Controller
+     */
+    protected $controller;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->controller = new Controller;
+        $this->controller->pushCurrent();
+
+        DebugBar::$bufferingEnabled = false;
+        DebugBar::initDebugBar();
+    }
+
+    public function testOnBeforeInit()
+    {
+        $this->controller->extend('onBeforeInit');
+
+        $self = $this;
+        DebugBar::withDebugBar(function (DebugBar\DebugBar $debugbar) use ($self) {
+            $controller = $debugbar->getCollector('silverstripe')->getController();
+            $self->assertInstanceOf('Controller', $controller);
+            $self->assertSame(Controller::curr(), $controller);
+
+            $timeData = $debugbar['time'];
+            $self->assertInstanceOf('DebugBar\DataCollector\TimeDataCollector', $timeData);
+
+            $self->assertFalse($timeData->hasStartedMeasure('pre_request'));
+            $self->assertTrue($timeData->hasStartedMeasure('init'));
+        });
+    }
+
+    public function testOnAfterInit()
+    {
+        $this->controller->extend('onAfterInit');
+
+        $self = $this;
+        DebugBar::withDebugBar(function (DebugBar\DebugBar $debugbar) use ($self) {
+            $timeData = $debugbar->getCollector('time');
+            $self->assertInstanceOf('DebugBar\DataCollector\TimeDataCollector', $timeData);
+
+            $self->assertFalse($timeData->hasStartedMeasure('cms_init'));
+            $self->assertFalse($timeData->hasStartedMeasure('init'));
+            $self->assertTrue($timeData->hasStartedMeasure('handle'));
+        });
+    }
+
+    public function testBeforeCallActionHandler()
+    {
+        $request = new SS_HTTPRequest('GET', '/');
+        $action = 'someaction';
+        $this->controller->extend('beforeCallActionHandler', $request, $action);
+
+        $self = $this;
+        DebugBar::withDebugBar(function (DebugBar\DebugBar $debugbar) use ($self) {
+            $timeData = $debugbar->getCollector('time');
+            $self->assertInstanceOf('DebugBar\DataCollector\TimeDataCollector', $timeData);
+
+            $self->assertFalse($timeData->hasStartedMeasure('handle'));
+            $self->assertTrue($timeData->hasStartedMeasure('action'));
+        });
+
+        $this->assertTrue($this->controller->beforeCallActionHandlerCalled);
+    }
+
+    public function testAfterCallActionHandler()
+    {
+        $request = new SS_HTTPRequest('GET', '/');
+        $action = 'someaction';
+        $result = null;
+        $this->controller->extend('afterCallActionHandler', $request, $action, $result);
+
+        $self = $this;
+        DebugBar::withDebugBar(function (DebugBar\DebugBar $debugbar) use ($self) {
+            $timeData = $debugbar->getCollector('time');
+            $self->assertInstanceOf('DebugBar\DataCollector\TimeDataCollector', $timeData);
+
+            $self->assertFalse($timeData->hasStartedMeasure('action'));
+            $self->assertTrue($timeData->hasStartedMeasure('after_action'));
+        });
+    }
+}

--- a/tests/DebugBarControllerTest.php
+++ b/tests/DebugBarControllerTest.php
@@ -1,0 +1,26 @@
+<?php
+
+class DebugBarControllerTest extends FunctionalTest
+{
+    public function tearDown()
+    {
+        parent::tearDown();
+        DebugBar::clearDebugBar();
+    }
+
+    public function testErrorWhenStorageIsDisabled()
+    {
+        Config::inst()->update('DebugBar', 'enable_storage', false);
+        $result = $this->get('/__debugbar');
+        $this->assertEquals(404, $result->getStatusCode());
+        $this->assertEquals('Storage not enabled', (string) $result->getBody());
+    }
+
+    public function testErrorWhenModuleIsDisabled()
+    {
+        Config::inst()->update('DebugBar', 'disabled', true);
+        $result = $this->get('/__debugbar');
+        $this->assertEquals(404, $result->getStatusCode());
+        $this->assertEquals('DebugBar not enabled', (string) $result->getBody());
+    }
+}

--- a/tests/DebugBarDatabaseCollectorTest.php
+++ b/tests/DebugBarDatabaseCollectorTest.php
@@ -1,0 +1,68 @@
+<?php
+
+class DebugBarDatabaseCollectorTest extends SapphireTest
+{
+    /**
+     * @var DebugBarSilverStripeCollector
+     */
+    protected $collector;
+
+    protected $usesDatabase = true;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        DebugBar::initDebugBar();
+        $this->collector = DebugBar::getDebugBar()->getCollector('db');
+    }
+
+    public function testCollectorExists()
+    {
+        $this->assertInstanceOf('DebugBarDatabaseCollector', $this->collector);
+    }
+
+    public function testCollect()
+    {
+        $result = $this->collector->collect();
+
+        $this->assertGreaterThan(1, $result['nb_statements']);
+        $this->assertEquals(0, $result['nb_failed_statements']);
+        $this->assertCount($result['nb_statements'], $result['statements']);
+
+        $statement = array_shift($result['statements']);
+        $this->assertNotEmpty($statement['sql']);
+        $this->assertEquals(1, $statement['is_success']);
+        $this->assertContains('PHPUnit_Framework_TestCase', $statement['source']);
+    }
+
+    public function testGetWidgets()
+    {
+        $expected = array(
+            'database' => array(
+                'icon' => 'inbox',
+                'widget' => 'PhpDebugBar.Widgets.SQLQueriesWidget',
+                'map' => 'db',
+                'default' => '[]'
+            ),
+            'database:badge' => array(
+                'map' => 'db.nb_statements',
+                'default' => 0
+            )
+        );
+
+        $this->assertSame($expected, $this->collector->getWidgets());
+    }
+
+    public function testGetAssets()
+    {
+        $expected = array(
+            'base_path' => '/debugbar/javascript',
+            'base_url' => 'debugbar/javascript',
+            'css' => 'sqlqueries/widget.css',
+            'js' => 'sqlqueries/widget.js'
+        );
+
+        $this->assertSame($expected, $this->collector->getAssets());
+    }
+}

--- a/tests/DebugBarDatabaseNewProxyTest.php
+++ b/tests/DebugBarDatabaseNewProxyTest.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * @coversDefaultClass DebugBarDatabaseNewProxy
+ */
+class DebugBarDatabaseNewProxyTest extends SapphireTest
+{
+    /**
+     * @var DebugBarDatabaseNewProxy
+     */
+    protected $proxy;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->proxy = new DebugBarDatabaseNewProxy(DB::get_conn());
+    }
+
+    public function testGetAndSetShowQueries()
+    {
+        $this->proxy->setShowQueries(true);
+        $this->assertTrue($this->proxy->getShowQueries());
+        $this->proxy->setShowQueries(false);
+        $this->assertFalse($this->proxy->getShowQueries());
+    }
+
+    public function testGetAndSetConnectors()
+    {
+        $this->assertInstanceOf('DBConnector', $this->proxy->getConnector());
+        $connector = new MySQLiConnector;
+        $this->proxy->setConnector($connector);
+        $this->assertSame($connector, $this->proxy->getConnector());
+    }
+
+    public function testGetAndSetDatabaseSchemaManager()
+    {
+        $this->assertInstanceOf('DBSchemaManager', $this->proxy->getSchemaManager());
+        $manager = new MySQLSchemaManager;
+        $this->proxy->setSchemaManager($manager);
+        $this->assertSame($manager, $this->proxy->getSchemaManager());
+    }
+
+    public function testGetAndSetQueryBuilder()
+    {
+        $this->assertInstanceOf('DBQueryBuilder', $this->proxy->getQueryBuilder());
+        $queryBuilder = new MySQLQueryBuilder;
+        $this->proxy->setQueryBuilder($queryBuilder);
+        $this->assertSame($queryBuilder, $this->proxy->getQueryBuilder());
+    }
+
+    /**
+     * Test method to ensure that a set of methods are proxied through to the real connection. This test covers
+     * all methods listed below:
+     *
+     * @covers ::addslashes
+     * @covers ::alterTable
+     * @covers ::comparisonClause
+     * @covers ::createDatabase
+     * @covers ::createField
+     * @covers ::createTable
+     * @covers ::datetimeDifferenceClause
+     * @covers ::datetimeIntervalClause
+     * @covers ::enumValuesForField
+     * @covers ::fieldList
+     * @covers ::formattedDatetimeClause
+     * @covers ::getConnect
+     * @covers ::getGeneratedID
+     * @covers ::hasTable
+     * @covers ::isActive
+     * @covers ::renameField
+     * @covers ::renameTable
+     * @covers ::supportsTimezoneOverride
+     * @covers ::supportsTransactions
+     * @covers ::tableList
+     * @covers ::transactionEnd
+     * @covers ::transactionRollback
+     * @covers ::transactionSavepoint
+     * @covers ::transactionStart
+     * @covers ::clearTable
+     * @covers ::getDatabaseServer
+     * @covers ::now
+     * @covers ::random
+     * @covers ::searchEngine
+     * @covers ::supportsCollations
+     */
+    public function testMethodsAreProxiedToRealConnection()
+    {
+        $mockConnection = $this->getMockBuilder('MySQLDatabase')
+            ->setMethods(array('fieldList', 'addslashes', 'random'))
+            ->getMock();
+
+        $mockConnection->expects($this->once())->method('fieldList');
+        $mockConnection->expects($this->once())->method('addslashes');
+        $mockConnection->expects($this->once())->method('random');
+
+        $proxy = new DebugBarDatabaseNewProxy($mockConnection);
+
+        $proxy->fieldList('foo');
+        $proxy->addslashes('bar');
+        $proxy->random();
+    }
+}

--- a/tests/DebugBarDatabaseNewProxyTest.php
+++ b/tests/DebugBarDatabaseNewProxyTest.php
@@ -1,7 +1,5 @@
 <?php
-/**
- * @coversDefaultClass DebugBarDatabaseNewProxy
- */
+
 class DebugBarDatabaseNewProxyTest extends SapphireTest
 {
     /**
@@ -50,52 +48,49 @@ class DebugBarDatabaseNewProxyTest extends SapphireTest
     /**
      * Test method to ensure that a set of methods are proxied through to the real connection. This test covers
      * all methods listed below:
-     *
-     * @covers ::addslashes
-     * @covers ::alterTable
-     * @covers ::comparisonClause
-     * @covers ::createDatabase
-     * @covers ::createField
-     * @covers ::createTable
-     * @covers ::datetimeDifferenceClause
-     * @covers ::datetimeIntervalClause
-     * @covers ::enumValuesForField
-     * @covers ::fieldList
-     * @covers ::formattedDatetimeClause
-     * @covers ::getConnect
-     * @covers ::getGeneratedID
-     * @covers ::hasTable
-     * @covers ::isActive
-     * @covers ::renameField
-     * @covers ::renameTable
-     * @covers ::supportsTimezoneOverride
-     * @covers ::supportsTransactions
-     * @covers ::tableList
-     * @covers ::transactionEnd
-     * @covers ::transactionRollback
-     * @covers ::transactionSavepoint
-     * @covers ::transactionStart
-     * @covers ::clearTable
-     * @covers ::getDatabaseServer
-     * @covers ::now
-     * @covers ::random
-     * @covers ::searchEngine
-     * @covers ::supportsCollations
      */
     public function testMethodsAreProxiedToRealConnection()
     {
-        $mockConnection = $this->getMockBuilder('MySQLDatabase')
-            ->setMethods(array('fieldList', 'addslashes', 'random'))
-            ->getMock();
+        $proxyMethods = array(
+            'addslashes',
+            'alterTable',
+            'comparisonClause',
+            'createDatabase',
+            'createField',
+            'createTable',
+            'datetimeDifferenceClause',
+            'datetimeIntervalClause',
+            'enumValuesForField',
+            'fieldList',
+            'formattedDatetimeClause',
+            'getConnect',
+            'getGeneratedID',
+            'hasTable',
+            'isActive',
+            'renameField',
+            'renameTable',
+            'supportsTimezoneOverride',
+            'supportsTransactions',
+            'tableList',
+            'transactionEnd',
+            'transactionRollback',
+            'transactionSavepoint',
+            'transactionStart',
+            'clearTable',
+            'getDatabaseServer',
+            'now',
+            'random',
+            'searchEngine',
+            'supportsCollations',
+        );
 
-        $mockConnection->expects($this->once())->method('fieldList');
-        $mockConnection->expects($this->once())->method('addslashes');
-        $mockConnection->expects($this->once())->method('random');
-
+        $mockConnection = $this->getMockBuilder('MySQLDatabase')->setMethods($proxyMethods)->getMock();
         $proxy = new DebugBarDatabaseNewProxy($mockConnection);
 
-        $proxy->fieldList('foo');
-        $proxy->addslashes('bar');
-        $proxy->random();
+        foreach ($proxyMethods as $proxyMethod) {
+            $mockConnection->expects($this->once())->method($proxyMethod);
+            // Pass mock arguments - the large number is in searchEngine
+            $proxy->$proxyMethod(null, null, null, null, null, null, null, null);
+        }
     }
 }

--- a/tests/DebugBarLeftAndMainExtensionTest.php
+++ b/tests/DebugBarLeftAndMainExtensionTest.php
@@ -1,0 +1,44 @@
+<?php
+
+class DebugBarLeftAndMainExtensionTest extends SapphireTest
+{
+    /**
+     * @var DebugBarLeftAndMainExtension
+     */
+    protected $extension;
+
+    /**
+     * @var DebugBar\DataCollector\TimeDataCollector
+     */
+    protected $timeCollector;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->extension = new DebugBarLeftAndMainExtension;
+        DebugBar::initDebugBar();
+        $this->timeCollector = DebugBar::getDebugBar()->getCollector('time');
+    }
+
+    public function tearDown()
+    {
+        DebugBar::clearDebugBar();
+
+        parent::tearDown();
+    }
+
+    public function testAccessedCms()
+    {
+        $this->extension->accessedCMS();
+        $this->assertFalse($this->timeCollector->hasStartedMeasure('init'));
+        $this->assertTrue($this->timeCollector->hasStartedMeasure('cms_accessed'));
+    }
+
+    public function testInit()
+    {
+        $this->extension->init();
+        $this->assertFalse($this->timeCollector->hasStartedMeasure('cms_accessed'));
+        $this->assertTrue($this->timeCollector->hasStartedMeasure('cms_init'));
+    }
+}

--- a/tests/DebugBarLogWriterTest.php
+++ b/tests/DebugBarLogWriterTest.php
@@ -1,0 +1,84 @@
+<?php
+
+class DebugBarLogWriterTest extends SapphireTest
+{
+    /**
+     * Init manually because we are running tests
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        DebugBar::initDebugBar();
+    }
+
+    /**
+     * Prevent global state from affecting each test by resetting the SS_Log writers to avoid duplicates and
+     * clear the state of the debug bar
+     */
+    public function tearDown()
+    {
+        SS_Log::clear_writers();
+        DebugBar::clearDebugBar();
+        parent::tearDown();
+    }
+
+    /**
+     * Do we have a logger?
+     */
+    public function testDebugBarLoggerIsAdded()
+    {
+        $writers = SS_Log::get_writers();
+        $found = false;
+        foreach ($writers as $writer) {
+            if ($writer instanceof DebugBarLogWriter) {
+                $found = true;
+            }
+        }
+        $this->assertTrue($found, 'DebugBarLogWriter was not added to SS_Log\'s log writers');
+    }
+
+    public function testFactory()
+    {
+        $instance = DebugBarLogWriter::factory(['foo']);
+        $this->assertInstanceOf('DebugBarLogWriter', $instance);
+    }
+
+    public function testLogLevels()
+    {
+        $debugBar = DebugBar::getDebugBar();
+
+        $collector = $debugBar->getCollector('messages');
+        $this->assertInstanceOf('DebugBar\DataCollector\MessagesCollector', $collector);
+        $collector->clear();
+
+        SS_Log::log('This is a notice', SS_Log::NOTICE);
+        $messages = $collector->getMessages();
+        $this->assertCount(1, $messages);
+        $this->assertSame('info', $messages[0]['label']);
+        $this->assertContains('This is a notice', $messages[0]['message']);
+
+        SS_Log::log('This is a warning', SS_Log::WARN);
+        $messages = $collector->getMessages();
+        $this->assertCount(2, $messages);
+        $this->assertSame('warning', $messages[1]['label']);
+        $this->assertContains('This is a warning', $messages[1]['message']);
+
+        SS_Log::log('This is an error', SS_Log::ERR);
+        $messages = $collector->getMessages();
+        $this->assertCount(3, $messages);
+        $this->assertSame('error', $messages[2]['label']);
+        $this->assertContains('This is an error', $messages[2]['message']);
+    }
+
+    public function testBackslashesAreEscaped()
+    {
+        $debugBar = DebugBar::getDebugBar();
+        $collector = $debugBar->getCollector('messages');
+        $collector->clear();
+
+        SS_Log::log('There was an error in \Some\Namespaced\Class', SS_Log::NOTICE);
+        $messages = $collector->getMessages();
+        $message = array_pop($messages);
+        $this->assertContains('\\\\Some\\\\Namespaced\\\\Class', $message['message']);
+    }
+}

--- a/tests/DebugBarSilverStripeCollectorTest.php
+++ b/tests/DebugBarSilverStripeCollectorTest.php
@@ -1,0 +1,152 @@
+<?php
+
+class DebugBarSilverStripeCollectorTest extends SapphireTest
+{
+    /**
+     * @var DebugBarSilverStripeCollector
+     */
+    protected $collector;
+
+    protected $usesDatabase = true;
+
+    public function setUp()
+    {
+        parent::setUp();
+        DebugBar::initDebugBar();
+        $this->collector = DebugBar::getDebugBar()->getCollector('silverstripe');
+    }
+
+    public function testCollectorExists()
+    {
+        $this->assertInstanceOf('DebugBarSilverStripeCollector', $this->collector);
+    }
+
+    public function testCollect()
+    {
+        $data = $this->collector->collect();
+
+        $this->assertArrayHasKey('debug', $data);
+        $this->assertArrayHasKey('locale', $data);
+        $this->assertArrayHasKey('parameters', $data);
+        $this->assertContains('Framework', $data['version']);
+        $this->assertSame('SiteConfig', $data['config']['ClassName']);
+        $this->assertSame('User, ADMIN', $data['user']);
+        $this->assertCount(0, $data['requirements']);
+
+        Member::currentUser()->logOut();
+        $data = $this->collector->collect();
+        $this->assertSame('Not logged in', $data['user']);
+    }
+
+    public function testShowRequirements()
+    {
+        Requirements::css(DEBUGBAR_DIR . '/assets/debugbar.css');
+        $data = $this->collector->collect();
+        $this->assertContains('assets/debugbar.css', $data['requirements'][0]);
+    }
+
+    public function testShowRequestParameters()
+    {
+        $controller = new Controller;
+        $controller->init();
+        $controller->setRequest(
+            new SS_HTTPRequest(
+                'GET',
+                '/',
+                array('getvar' => 'value', 'foo' => 'bar'),
+                array('postvar' => 'value', 'bar' => 'baz')
+            )
+        );
+        $controller->getRequest()->setRouteParams(array('something' => 'here'));
+
+        $this->collector->setController($controller);
+        $this->assertSame($controller, $this->collector->getController());
+
+        $result = DebugBarSilverStripeCollector::getRequestParameters();
+        $this->assertSame('value', $result['GET - getvar']);
+        $this->assertSame('baz', $result['POST - bar']);
+        $this->assertSame('here', $result['ROUTE - something']);
+    }
+
+    public function testGetSessionData()
+    {
+        Session::set('DebugBarTesting', 'test value');
+        $result = DebugBarSilverStripeCollector::getSessionData();
+        $this->assertSame('test value', $result['DebugBarTesting']);
+    }
+
+    public function testGetConfigData()
+    {
+        $result = DebugBarSilverStripeCollector::getConfigData();
+        $this->assertSame('SiteConfig', $result['ClassName']);
+        $this->assertArrayHasKey('Title', $result);
+        $this->assertArrayHasKey('ID', $result);
+        $this->assertArrayHasKey('Created', $result);
+    }
+
+    public function testGetWidgets()
+    {
+        $expected = array(
+            'user' => array(
+                'icon' => 'user',
+                'tooltip' => 'Current member',
+                'map' => 'silverstripe.user',
+                'default' => '',
+            ),
+            'version' => array(
+                'icon' => 'bullseye',
+                'tooltip' => 'Version',
+                'map' => 'silverstripe.version',
+                'default' => '',
+            ),
+            'locale' => array(
+                'icon' => 'flag',
+                'tooltip' => 'Current locale',
+                'map' => 'silverstripe.locale',
+                'default' => '',
+            ),
+            'session' => array(
+                'icon' => 'archive',
+                'widget' => 'PhpDebugBar.Widgets.VariableListWidget',
+                'map' => 'silverstripe.session',
+                'default' => '{}',
+            ),
+            'cookies' => array(
+                'icon' => 'asterisk',
+                'widget' => 'PhpDebugBar.Widgets.VariableListWidget',
+                'map' => 'silverstripe.cookies',
+                'default' => '{}',
+            ),
+            'parameters' => array(
+                'icon' => 'arrow-right',
+                'widget' => 'PhpDebugBar.Widgets.VariableListWidget',
+                'map' => 'silverstripe.parameters',
+                'default' => '{}',
+            ),
+            'config' => array(
+                'icon' => 'gear',
+                'widget' => 'PhpDebugBar.Widgets.VariableListWidget',
+                'map' => 'silverstripe.config',
+                'default' => '{}',
+            ),
+            'requirements' => array(
+                'icon' => 'file-o ',
+                'widget' => 'PhpDebugBar.Widgets.ListWidget',
+                'map' => 'silverstripe.requirements',
+                'default' => '{}',
+            )
+        );
+        $this->assertSame($expected, $this->collector->getWidgets());
+    }
+
+    public function testGetAssets()
+    {
+        $expected = array(
+            'base_path' => '/debugbar/javascript',
+            'base_url' => 'debugbar/javascript',
+            'css' => [],
+            'js' => 'widgets.js',
+        );
+        $this->assertSame($expected, $this->collector->getAssets());
+    }
+}

--- a/tests/DebugBarTest.php
+++ b/tests/DebugBarTest.php
@@ -3,9 +3,8 @@
 /**
  * Tests for DebugBar
  */
-class DebugBarTest extends FunctionalTest
+class DebugBarTest extends SapphireTest
 {
-
     public function setUp()
     {
         parent::setUp();
@@ -71,16 +70,6 @@ class DebugBarTest extends FunctionalTest
         $this->assertTrue((bool) strpos($content, "Value for: 'test'"), "Value for test not found");
         $this->assertTrue((bool) strpos($content, 'sf-dump'), "Symfony dumper not found");
         $this->assertTrue((bool) strpos($content, '<span style="font-weight:bold;">SELECT</span>'), "Sql formatted query not found");
-    }
-
-    public function testShowOnHomepage()
-    {
-        $this->markTestIncomplete('Robbie: todo');
-
-        $content = (string) $this->get('/')->getBody();
-
-        $this->assertContains('"/debugbar/assets/debugbar.js', $content, "Base script not found");
-        $this->assertContains('var phpdebugbar = new PhpDebugBar.DebugBar();', $content, "Init script not found");
     }
 
     /**


### PR DESCRIPTION
Also adds silverstripe/siteconfig as a composer dependency as it's used in DebugBarSilverStripeCollector.

Contains the commit from #19 as well (not merged yet).

Resolves #21 