### PR TITLE
FIX load bundled jQuery in no-conflict mode

### DIFF
--- a/code/DebugBar.php
+++ b/code/DebugBar.php
@@ -181,8 +181,7 @@ class DebugBar extends Object
         $renderer->setBasePath(DEBUGBAR_DIR . '/assets');
         $renderer->setBaseUrl(DEBUGBAR_DIR . '/assets');
 
-        $renderer->disableVendor('jquery');
-        $renderer->setEnableJqueryNoConflict(false);
+        $renderer->setEnableJqueryNoConflict(true);
 
         if (DebugBar::config()->enable_storage) {
             $renderer->setOpenHandlerUrl('__debugbar');


### PR DESCRIPTION
This loads the debugbar on the front-end by default in a non conflicting mode.
References #12 