### PR TITLE
NEW Add configurable warning threshold for DB queries that take X seconds, visual indicator = red

### DIFF
--- a/_config/debugbar.yml
+++ b/_config/debugbar.yml
@@ -17,6 +17,8 @@ DebugBar:
   find_source: true
   enabled_in_admin: true
   query_limit: 200
+  # Threshold (seconds) for how long a database query can run for before it will be shown as a warning
+  warn_dbqueries_threshold_seconds: 1.0
 Director:
   rules:
     '__debugbar': 'DebugBarController'

--- a/code/DebugBarDatabaseCollector.php
+++ b/code/DebugBarDatabaseCollector.php
@@ -65,6 +65,7 @@ class DebugBarDatabaseCollector extends DataCollector implements Renderable, Ass
         $i       = 0;
         $queries = $this->db->getQueries();
         $limit   = DebugBar::config()->query_limit;
+        $warnDurationThreshold = Config::inst()->get('DebugBar', 'warn_dbqueries_threshold_seconds');
 
         $showDb = count(array_unique(array_map(function ($stmt) {
                 return $stmt['database'];
@@ -98,6 +99,7 @@ class DebugBarDatabaseCollector extends DataCollector implements Renderable, Ass
                 'is_success' => $stmt['success'],
                 'database' => $showDb ? $stmt['database'] : null,
                 'source' => $stmt['source'],
+                'warn' => $stmt['duration'] > $warnDurationThreshold
             ];
 
             if ($timeCollector !== null) {

--- a/javascript/sqlqueries/widget.css
+++ b/javascript/sqlqueries/widget.css
@@ -102,6 +102,18 @@ div.phpdebugbar-widgets-sqlqueries li.phpdebugbar-widgets-list-item.phpdebugbar-
     background-color: #e3e3e3;
 }
 
+div.phpdebugbar-widgets-sqlqueries li.phpdebugbar-widgets-list-item.phpdebugbar-widgets-database-time-warning {
+    background-color: rgba(255, 0, 0, .1);
+}
+
+div.phpdebugbar-widgets-sqlqueries li.phpdebugbar-widgets-list-item.phpdebugbar-widgets-database-time-warning .phpdebugbar-widgets-duration {
+    color: red;
+}
+
+div.phpdebugbar-widgets-sqlqueries li.phpdebugbar-widgets-list-item.phpdebugbar-widgets-database-time-warning:hover {
+    background-color: rgba(255, 0, 0, .12);
+}
+
 div.phpdebugbar-widgets-sqlqueries .phpdebugbar-widgets-badge {
     float: right;
     margin-left: 8px;

--- a/javascript/sqlqueries/widget.js
+++ b/javascript/sqlqueries/widget.js
@@ -57,6 +57,9 @@
                     if (typeof (stmt.stmt_id) != 'undefined' && stmt.stmt_id) {
                         $('<span title="Prepared statement ID" />').addClass(csscls('stmt-id')).text(stmt.stmt_id).appendTo(li);
                     }
+                    if (typeof stmt.warn !== 'undefined' && stmt.warn) {
+                        li.addClass(csscls('database-time-warning'));
+                    }
                     if (stmt.database) {
                         $('<span title="Database" />').addClass(csscls('database')).text(stmt.database).appendTo(li);
                         li.addClass(csscls('database' + stmt.database));

--- a/tests/DebugBarDatabaseCollectorTest.php
+++ b/tests/DebugBarDatabaseCollectorTest.php
@@ -24,6 +24,8 @@ class DebugBarDatabaseCollectorTest extends SapphireTest
 
     public function testCollect()
     {
+        // Deliberately high warning threshold
+        Config::inst()->update('DebugBar', 'warn_dbqueries_threshold_seconds', 200);
         $result = $this->collector->collect();
 
         $this->assertGreaterThan(1, $result['nb_statements']);
@@ -34,6 +36,15 @@ class DebugBarDatabaseCollectorTest extends SapphireTest
         $this->assertNotEmpty($statement['sql']);
         $this->assertEquals(1, $statement['is_success']);
         $this->assertContains('PHPUnit_Framework_TestCase', $statement['source']);
+        $this->assertFalse($statement['warn']);
+
+        // Deliberately low warning threshold
+        Config::inst()->update('DebugBar', 'warn_dbqueries_threshold_seconds', 0.0000001);
+        $result = $this->collector->collect();
+
+        $this->assertNotEmpty($result['statements']);
+        $statement = array_shift($result['statements']);
+        $this->assertTrue($statement['warn']);
     }
 
     public function testGetWidgets()


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5170590/27815799-25662da4-60db-11e7-8498-a82b723cf9d3.png)
