### PR TITLE
ENHANCEMENT PHP53 support enabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@
 language: php
 
 php:
+  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/_config.php
+++ b/_config.php
@@ -51,7 +51,7 @@ if (!function_exists('d')) {
         preg_match("/d\((.+)\)/", $src_line, $matches);
 
         // Find all arguments, ignore variables within parenthesis
-        $arguments_name = [];
+        $arguments_name = array();
         if (!empty($matches[1])) {
             $arguments_name = array_map('trim', preg_split("/(?![^(]*\)),/", $matches[1]));
         }
@@ -85,7 +85,7 @@ if (!function_exists('d')) {
 
         // Display data in a friendly manner
         if (empty($args)) {
-            $arguments_name = [];
+            $arguments_name = array();
             foreach ($bt as $trace) {
                 if (!empty($trace['object'])) {
                     $line = isset($trace['line']) ? $trace['line'] : 0;

--- a/code/DebugBar.php
+++ b/code/DebugBar.php
@@ -280,7 +280,7 @@ class DebugBar extends Object
             return false;
         }
         if (isset($_SERVER['REMOTE_ADDR'])) {
-            return !in_array($_SERVER['REMOTE_ADDR'], ['127.0.0.1', '::1', '1']);
+            return !in_array($_SERVER['REMOTE_ADDR'], array('127.0.0.1', '::1', '1'));
         }
         return false;
     }

--- a/code/DebugBarDatabaseCollector.php
+++ b/code/DebugBarDatabaseCollector.php
@@ -55,7 +55,7 @@ class DebugBarDatabaseCollector extends DataCollector implements Renderable, Ass
      */
     protected function collectData(TimeDataCollector $timeCollector = null)
     {
-        $stmts = [];
+        $stmts = array();
 
         $total_duration = 0;
         $total_mem      = 0;
@@ -82,13 +82,13 @@ class DebugBarDatabaseCollector extends DataCollector implements Renderable, Ass
             }
 
             if ($limit && $i > $limit) {
-                $stmts[] = [
+                $stmts[] = array(
                     'sql' => "Only the first $limit queries are shown"
-                ];
+                );
                 break;
             }
 
-            $stmts[] = [
+            $stmts[] = array(
                 'sql' => $stmt['short_query'],
                 'row_count' => $stmt['rows'],
                 'params' => $stmt['select'] ? $stmt['select'] : null,
@@ -100,7 +100,7 @@ class DebugBarDatabaseCollector extends DataCollector implements Renderable, Ass
                 'database' => $showDb ? $stmt['database'] : null,
                 'source' => $stmt['source'],
                 'warn' => $stmt['duration'] > $warnDurationThreshold
-            ];
+            );
 
             if ($timeCollector !== null) {
                 $timeCollector->addMeasure(
@@ -111,7 +111,7 @@ class DebugBarDatabaseCollector extends DataCollector implements Renderable, Ass
             }
         }
 
-        return [
+        return array(
             'nb_statements' => count($queries),
             'nb_failed_statements' => $failed,
             'statements' => $stmts,
@@ -119,7 +119,7 @@ class DebugBarDatabaseCollector extends DataCollector implements Renderable, Ass
             'accumulated_duration_str' => $this->getDataFormatter()->formatDuration($total_duration),
             'memory_usage' => $total_mem,
             'memory_usage_str' => $this->getDataFormatter()->formatBytes($total_mem),
-        ];
+        );
     }
 
     /**
@@ -135,18 +135,18 @@ class DebugBarDatabaseCollector extends DataCollector implements Renderable, Ass
      */
     public function getWidgets()
     {
-        return [
-            "database" => [
+        return array(
+            "database" => array(
                 "icon" => "inbox",
                 "widget" => "PhpDebugBar.Widgets.SQLQueriesWidget",
                 "map" => "db",
                 "default" => "[]"
-            ],
-            "database:badge" => [
+            ),
+            "database:badge" => array(
                 "map" => "db.nb_statements",
                 "default" => 0
-            ]
-        ];
+            )
+        );
     }
 
     /**
@@ -154,11 +154,11 @@ class DebugBarDatabaseCollector extends DataCollector implements Renderable, Ass
      */
     public function getAssets()
     {
-        return [
+        return array(
             'base_path' => '/'.DEBUGBAR_DIR.'/javascript',
             'base_url' => DEBUGBAR_DIR.'/javascript',
             'css' => 'sqlqueries/widget.css',
             'js' => 'sqlqueries/widget.js'
-        ];
+        );
     }
 }

--- a/code/DebugBarDatabaseNewProxy.php
+++ b/code/DebugBarDatabaseNewProxy.php
@@ -31,7 +31,7 @@ class DebugBarDatabaseNewProxy extends SS_Database
         $this->connector     = $this->connector ? : $realConn->getConnector();
         $this->schemaManager = $this->schemaManager ? : $realConn->getSchemaManager();
         $this->queryBuilder  = $this->queryBuilder ? : $realConn->getQueryBuilder();
-        $this->queries       = [];
+        $this->queries       = array();
         $this->findSource    = DebugBar::config()->find_source;
     }
 
@@ -140,7 +140,7 @@ class DebugBarDatabaseNewProxy extends SS_Database
      * @param array $parameters
      * @return mixed Result of query
      */
-    protected function benchmarkQuery($sql, $callback, $parameters = [])
+    protected function benchmarkQuery($sql, $callback, $parameters = array())
     {
         $starttime   = microtime(true);
         $startmemory = memory_get_usage(true);
@@ -230,7 +230,7 @@ class DebugBarDatabaseNewProxy extends SS_Database
             $select = null;
         }
 
-        $this->queries[] = [
+        $this->queries[] = array(
             'raw_query' => $rawsql,
             'short_query' => $shortsql,
             'select' => $select,
@@ -243,7 +243,7 @@ class DebugBarDatabaseNewProxy extends SS_Database
             'success' => $handle ? true : false,
             'database' => $this->getSelectedDatabase(),
             'source' => $this->findSource ? $this->findSource() : null
-        ];
+        );
         return $handle;
     }
 
@@ -252,17 +252,17 @@ class DebugBarDatabaseNewProxy extends SS_Database
         $traces = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS | DEBUG_BACKTRACE_PROVIDE_OBJECT);
 
         // Not relevant to determine source
-        $internalClasses = [
+        $internalClasses = array(
             'DB', 'SQLExpression', 'DataList', 'DataObject',
             'DataQuery', 'SQLSelect', 'SQLQuery', 'SS_Map', 'SS_ListDecorator', 'Object'
-        ];
+        );
 
-        $viewerClasses = [
+        $viewerClasses = array(
             'SSViewer_DataPresenter', 'SSViewer_Scope', 'SSViewer',
             'ViewableData'
-        ];
+        );
 
-        $sources = [];
+        $sources = array();
         foreach ($traces as $trace) {
             $class    = isset($trace['class']) ? $trace['class'] : null;
             $line     = isset($trace['line']) ? $trace['line'] : null;
@@ -389,7 +389,7 @@ class DebugBarDatabaseNewProxy extends SS_Database
         // Benchmark query
         $connector = $this->connector;
         return $this->benchmarkQuery(
-            [$sql, $parameters],
+            array($sql, $parameters),
             function ($sql) use ($connector, $parameters, $errorLevel) {
                 return $connector->preparedQuery($sql, $parameters, $errorLevel);
             }
@@ -412,13 +412,13 @@ class DebugBarDatabaseNewProxy extends SS_Database
     public function __call($name, $arguments)
     {
         //return call_user_func_array([$this->realConn, __FUNCTION__],            func_get_args());
-        return call_user_func_array([$this->realConn, $name], $arguments);
+        return call_user_func_array(array($this->realConn, $name), $arguments);
     }
 
     public function addslashes($val)
     {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -433,7 +433,7 @@ class DebugBarDatabaseNewProxy extends SS_Database
         $advancedOptions = null
     ) {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -447,7 +447,7 @@ class DebugBarDatabaseNewProxy extends SS_Database
         $parameterised = false
     ) {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -455,7 +455,7 @@ class DebugBarDatabaseNewProxy extends SS_Database
     public function createDatabase()
     {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -463,7 +463,7 @@ class DebugBarDatabaseNewProxy extends SS_Database
     public function createField($table, $field, $spec)
     {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -476,7 +476,7 @@ class DebugBarDatabaseNewProxy extends SS_Database
         $advancedOptions = null
     ) {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -484,7 +484,7 @@ class DebugBarDatabaseNewProxy extends SS_Database
     public function datetimeDifferenceClause($date1, $date2)
     {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -492,7 +492,7 @@ class DebugBarDatabaseNewProxy extends SS_Database
     public function datetimeIntervalClause($date, $interval)
     {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -500,7 +500,7 @@ class DebugBarDatabaseNewProxy extends SS_Database
     public function enumValuesForField($tableName, $fieldName)
     {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -508,7 +508,7 @@ class DebugBarDatabaseNewProxy extends SS_Database
     public function fieldList($table)
     {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -516,7 +516,7 @@ class DebugBarDatabaseNewProxy extends SS_Database
     public function formattedDatetimeClause($date, $format)
     {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -524,7 +524,7 @@ class DebugBarDatabaseNewProxy extends SS_Database
     public function getConnect($parameters)
     {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -532,7 +532,7 @@ class DebugBarDatabaseNewProxy extends SS_Database
     public function getGeneratedID($table)
     {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -540,7 +540,7 @@ class DebugBarDatabaseNewProxy extends SS_Database
     public function hasTable($tableName)
     {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -548,7 +548,7 @@ class DebugBarDatabaseNewProxy extends SS_Database
     public function isActive()
     {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -556,7 +556,7 @@ class DebugBarDatabaseNewProxy extends SS_Database
     public function renameField($tableName, $oldName, $newName)
     {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -564,7 +564,7 @@ class DebugBarDatabaseNewProxy extends SS_Database
     public function renameTable($oldTableName, $newTableName)
     {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -572,7 +572,7 @@ class DebugBarDatabaseNewProxy extends SS_Database
     public function supportsTimezoneOverride()
     {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -580,7 +580,7 @@ class DebugBarDatabaseNewProxy extends SS_Database
     public function supportsTransactions()
     {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -588,7 +588,7 @@ class DebugBarDatabaseNewProxy extends SS_Database
     public function tableList()
     {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -596,7 +596,7 @@ class DebugBarDatabaseNewProxy extends SS_Database
     public function transactionEnd($chain = false)
     {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -604,7 +604,7 @@ class DebugBarDatabaseNewProxy extends SS_Database
     public function transactionRollback($savepoint = false)
     {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -612,7 +612,7 @@ class DebugBarDatabaseNewProxy extends SS_Database
     public function transactionSavepoint($savepoint)
     {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -620,7 +620,7 @@ class DebugBarDatabaseNewProxy extends SS_Database
     public function transactionStart($transaction_mode = false, $session_characteristics = false)
     {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -628,7 +628,7 @@ class DebugBarDatabaseNewProxy extends SS_Database
     public function clearTable($table)
     {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -636,7 +636,7 @@ class DebugBarDatabaseNewProxy extends SS_Database
     public function getDatabaseServer()
     {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -644,7 +644,7 @@ class DebugBarDatabaseNewProxy extends SS_Database
     public function now()
     {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -652,7 +652,7 @@ class DebugBarDatabaseNewProxy extends SS_Database
     public function random()
     {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -669,7 +669,7 @@ class DebugBarDatabaseNewProxy extends SS_Database
         $invertedMatch = false
     ) {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -677,7 +677,7 @@ class DebugBarDatabaseNewProxy extends SS_Database
     public function supportsCollations()
     {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }

--- a/code/DebugBarDatabaseProxy.php
+++ b/code/DebugBarDatabaseProxy.php
@@ -26,7 +26,7 @@ class DebugBarDatabaseProxy extends SS_Database
     public function __construct($realConn)
     {
         $this->realConn   = $realConn;
-        $this->queries    = [];
+        $this->queries    = array();
         $this->findSource = DebugBar::config()->find_source;
     }
 
@@ -135,7 +135,7 @@ class DebugBarDatabaseProxy extends SS_Database
      * @param array $parameters
      * @return mixed Result of query
      */
-    protected function benchmarkQuery($sql, $callback, $parameters = [])
+    protected function benchmarkQuery($sql, $callback, $parameters = array())
     {
         $starttime   = microtime(true);
         $startmemory = memory_get_usage(true);
@@ -202,7 +202,7 @@ class DebugBarDatabaseProxy extends SS_Database
             $select = null;
         }
 
-        $this->queries[] = [
+        $this->queries[] = array(
             'raw_query' => $rawsql,
             'short_query' => $shortsql,
             'select' => $select,
@@ -215,7 +215,7 @@ class DebugBarDatabaseProxy extends SS_Database
             'success' => $handle ? true : false,
             'database' => $this->currentDatabase(),
             'source' => $this->findSource ? $this->findSource() : null
-        ];
+        );
         return $handle;
     }
 
@@ -224,17 +224,17 @@ class DebugBarDatabaseProxy extends SS_Database
         $traces = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS | DEBUG_BACKTRACE_PROVIDE_OBJECT);
 
         // Not relevant to determine source
-        $internalClasses = [
+        $internalClasses = array(
             'DB', 'SQLExpression', 'DataList', 'DataObject',
             'DataQuery', 'SQLSelect', 'SQLQuery', 'SS_Map', 'SS_ListDecorator', 'Object'
-        ];
+        );
 
-        $viewerClasses = [
+        $viewerClasses = array(
             'SSViewer_DataPresenter', 'SSViewer_Scope', 'SSViewer',
             'ViewableData'
-        ];
+        );
 
-        $sources = [];
+        $sources = array();
         foreach ($traces as $trace) {
             $class    = isset($trace['class']) ? $trace['class'] : null;
             $line     = isset($trace['line']) ? $trace['line'] : null;
@@ -384,13 +384,13 @@ class DebugBarDatabaseProxy extends SS_Database
     public function __call($name, $arguments)
     {
         //return call_user_func_array([$this->realConn, __FUNCTION__],            func_get_args());
-        return call_user_func_array([$this->realConn, $name], $arguments);
+        return call_user_func_array(array($this->realConn, $name), $arguments);
     }
 
     public function addslashes($val)
     {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -406,7 +406,7 @@ class DebugBarDatabaseProxy extends SS_Database
     ) {
 
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -421,7 +421,7 @@ class DebugBarDatabaseProxy extends SS_Database
     ) {
 
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -429,7 +429,7 @@ class DebugBarDatabaseProxy extends SS_Database
     public function createDatabase()
     {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -437,7 +437,7 @@ class DebugBarDatabaseProxy extends SS_Database
     public function createField($table, $field, $spec)
     {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -451,7 +451,7 @@ class DebugBarDatabaseProxy extends SS_Database
     ) {
 
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -459,7 +459,7 @@ class DebugBarDatabaseProxy extends SS_Database
     public function datetimeDifferenceClause($date1, $date2)
     {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -467,7 +467,7 @@ class DebugBarDatabaseProxy extends SS_Database
     public function datetimeIntervalClause($date, $interval)
     {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -475,7 +475,7 @@ class DebugBarDatabaseProxy extends SS_Database
     public function enumValuesForField($tableName, $fieldName)
     {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -483,7 +483,7 @@ class DebugBarDatabaseProxy extends SS_Database
     public function fieldList($table)
     {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -491,7 +491,7 @@ class DebugBarDatabaseProxy extends SS_Database
     public function formattedDatetimeClause($date, $format)
     {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -499,7 +499,7 @@ class DebugBarDatabaseProxy extends SS_Database
     public function getConnect($parameters)
     {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -507,7 +507,7 @@ class DebugBarDatabaseProxy extends SS_Database
     public function getGeneratedID($table)
     {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -515,7 +515,7 @@ class DebugBarDatabaseProxy extends SS_Database
     public function hasTable($tableName)
     {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -523,7 +523,7 @@ class DebugBarDatabaseProxy extends SS_Database
     public function isActive()
     {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -531,7 +531,7 @@ class DebugBarDatabaseProxy extends SS_Database
     public function renameField($tableName, $oldName, $newName)
     {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -539,7 +539,7 @@ class DebugBarDatabaseProxy extends SS_Database
     public function renameTable($oldTableName, $newTableName)
     {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -547,7 +547,7 @@ class DebugBarDatabaseProxy extends SS_Database
     public function supportsTimezoneOverride()
     {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -555,7 +555,7 @@ class DebugBarDatabaseProxy extends SS_Database
     public function supportsTransactions()
     {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -563,7 +563,7 @@ class DebugBarDatabaseProxy extends SS_Database
     public function tableList()
     {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -571,7 +571,7 @@ class DebugBarDatabaseProxy extends SS_Database
     public function transactionEnd($chain = false)
     {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -579,7 +579,7 @@ class DebugBarDatabaseProxy extends SS_Database
     public function transactionRollback($savepoint = false)
     {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -587,7 +587,7 @@ class DebugBarDatabaseProxy extends SS_Database
     public function transactionSavepoint($savepoint)
     {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -598,7 +598,7 @@ class DebugBarDatabaseProxy extends SS_Database
     ) {
 
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -606,7 +606,7 @@ class DebugBarDatabaseProxy extends SS_Database
     public function clearTable($table)
     {
         return call_user_func_array(
-            [$this->realConn, __FUNCTION__],
+            array($this->realConn, __FUNCTION__),
             func_get_args()
         );
     }
@@ -648,7 +648,7 @@ class DebugBarDatabaseProxy extends SS_Database
         $keywords           = $this->escapeString($keywords);
         $htmlEntityKeywords = htmlentities($keywords, ENT_NOQUOTES, 'UTF-8');
 
-        $extraFilters = ['SiteTree' => '', 'File' => ''];
+        $extraFilters = array('SiteTree' => '', 'File' => '');
 
         if ($booleanSearch) {
             $boolean = "IN BOOLEAN MODE";
@@ -685,8 +685,8 @@ class DebugBarDatabaseProxy extends SS_Database
             $match['File'] = "MATCH (Filename, Title, Content) AGAINST ('$keywords' $boolean) AND ClassName = 'File'";
 
             // We make the relevance search by converting a boolean mode search into a normal one
-            $relevanceKeywords = str_replace(['*', '+', '-'], '', $keywords);
-            $htmlEntityRelevanceKeywords = str_replace(['*', '+', '-'], '', $htmlEntityKeywords);
+            $relevanceKeywords = str_replace(array('*', '+', '-'), '', $keywords);
+            $htmlEntityRelevanceKeywords = str_replace(array('*', '+', '-'), '', $htmlEntityKeywords);
             $relevance['SiteTree']       = "MATCH (Title, MenuTitle, Content, MetaDescription) "
                 ."AGAINST ('$relevanceKeywords') "
                 ."+ MATCH (Title, MenuTitle, Content, MetaDescription) AGAINST ('$htmlEntityRelevanceKeywords')";
@@ -697,8 +697,8 @@ class DebugBarDatabaseProxy extends SS_Database
         }
 
         // Generate initial DataLists and base table names
-        $lists       = [];
-        $baseClasses = ['SiteTree' => '', 'File' => ''];
+        $lists       = array();
+        $baseClasses = array('SiteTree' => '', 'File' => '');
         foreach ($classesToSearch as $class) {
             $lists[$class] = DataList::create($class)->where($notMatch . $match[$class] . $extraFilters[$class], "");
             $baseClasses[$class] = '"' . $class . '"';
@@ -707,36 +707,36 @@ class DebugBarDatabaseProxy extends SS_Database
         $charset = Config::inst()->get('MySQLDatabase', 'charset');
 
         // Make column selection lists
-        $select = [
-            'SiteTree' => [
+        $select = array(
+            'SiteTree' => array(
                 "ClassName", "$baseClasses[SiteTree].\"ID\"", "ParentID",
                 "Title", "MenuTitle", "URLSegment", "Content",
                 "LastEdited", "Created",
                 "Filename" => "_{$charset}''", "Name" => "_{$charset}''",
                 "Relevance" => $relevance['SiteTree'], "CanViewType"
-            ],
-            'File' => [
+            ),
+            'File' => array(
                 "ClassName", "$baseClasses[File].\"ID\"", "ParentID",
                 "Title", "MenuTitle" => "_{$charset}''", "URLSegment" => "_{$charset}''",
                 "Content",
                 "LastEdited", "Created",
                 "Filename", "Name",
                 "Relevance" => $relevance['File'], "CanViewType" => "NULL"
-            ],
-        ];
+            ),
+        );
 
         // Process and combine queries
-        $querySQLs       = [];
-        $queryParameters = [];
+        $querySQLs       = array();
+        $queryParameters = array();
         $totalCount      = 0;
         foreach ($lists as $class => $list) {
             $query = $list->dataQuery()->query();
 
             // There's no need to do all that joining
-            $replacedString = str_replace(['"', '`'], '', $baseClasses[$class]);
-            $query->setFrom([$replacedString => $baseClasses[$class]]);
+            $replacedString = str_replace(array('"', '`'), '', $baseClasses[$class]);
+            $query->setFrom(array($replacedString => $baseClasses[$class]));
             $query->setSelect($select[$class]);
-            $query->setOrderBy([]);
+            $query->setOrderBy(array());
 
             $querySQLs[]     = $query->sql($parameters);
             $queryParameters = array_merge($queryParameters, $parameters);
@@ -748,7 +748,7 @@ class DebugBarDatabaseProxy extends SS_Database
         // Get records
         $records = $this->preparedQuery($fullQuery, $queryParameters);
 
-        $objects = [];
+        $objects = array();
 
         foreach ($records as $record) {
             $objects[] = new $record['ClassName']($record);

--- a/code/DebugBarLogWriter.php
+++ b/code/DebugBarLogWriter.php
@@ -11,11 +11,11 @@ class DebugBarLogWriter extends Zend_Log_Writer_Abstract
      *
      * @var array
      */
-    protected $levelsMap = [
+    protected $levelsMap = array(
         'NOTICE' => 'info',
         'WARN' => 'warning',
         'ERR' => 'error'
-    ];
+    );
 
     /**
      * The default log level to use if not recognised (MessagesCollector format)

--- a/code/DebugBarSilverStripeCollector.php
+++ b/code/DebugBarSilverStripeCollector.php
@@ -7,12 +7,12 @@ use DebugBar\DataCollector\Renderable;
 class DebugBarSilverStripeCollector extends DataCollector implements Renderable, AssetProvider
 {
 
-    protected static $debug = [];
+    protected static $debug = array();
     protected static $controller;
 
     public function collect()
     {
-        $data = [
+        $data = array(
             'debugcount' => count(self::$debug),
             'debug' => self::$debug,
             'session' => self::getSessionData(),
@@ -24,7 +24,7 @@ class DebugBarSilverStripeCollector extends DataCollector implements Renderable,
             'requirements' => self::getRequirementsData(),
             'user' => Member::currentUserID() ? Member::currentUser()->Title : 'Not logged in',
             'templates' => self::getTemplateData(),
-        ];
+        );
         return $data;
     }
 
@@ -34,7 +34,7 @@ class DebugBarSilverStripeCollector extends DataCollector implements Renderable,
      */
     public static function getTemplateData()
     {
-        $result = [];
+        $result = array();
         $controller = self::$controller;
         if ($controller) {
             /** @var SSViewer $viewer */
@@ -60,17 +60,17 @@ class DebugBarSilverStripeCollector extends DataCollector implements Renderable,
         if (!empty($matches[1])) {
             return $matches[1];
         }
-        return [];
+        return array();
     }
 
     public static function getRequestParameters()
     {
         if (!self::$controller) {
-            return [];
+            return array();
         }
         $request = self::$controller->getRequest();
 
-        $p = [];
+        $p = array();
         foreach ($request->getVars() as $k => $v) {
             $p["GET - $k"] = $v;
         }
@@ -95,7 +95,7 @@ class DebugBarSilverStripeCollector extends DataCollector implements Renderable,
     public static function getSessionData()
     {
         $data = Session::get_all();
-        $filtered = [];
+        $filtered = array();
 
         // Filter not useful data
         foreach ($data as $k => $v) {
@@ -176,71 +176,71 @@ class DebugBarSilverStripeCollector extends DataCollector implements Renderable,
             }
         }
 
-        $widgets = [
-            'user' => [
+        $widgets = array(
+            'user' => array(
                 'icon' => $userIcon,
                 'tooltip' => $userText,
                 "default" => "",
-            ],
-            "version" => [
+            ),
+            "version" => array(
                 "icon" => "desktop",
                 "tooltip" => LeftAndMain::create()->CMSVersion(),
                 "default" => ""
-            ],
-            "locale" => [
+            ),
+            "locale" => array(
                 "icon" => "globe",
                 "tooltip" => i18n::get_locale(),
                 "default" => "",
-            ],
-            "session" => [
+            ),
+            "session" => array(
                 "icon" => "archive",
                 "widget" => "PhpDebugBar.Widgets.VariableListWidget",
                 "map" => "$name.session",
                 "default" => "{}"
-            ],
-            "cookies" => [
+            ),
+            "cookies" => array(
                 "icon" => "asterisk",
                 "widget" => "PhpDebugBar.Widgets.VariableListWidget",
                 "map" => "$name.cookies",
                 "default" => "{}"
-            ],
-            "parameters" => [
+            ),
+            "parameters" => array(
                 "icon" => "arrow-right",
                 "widget" => "PhpDebugBar.Widgets.VariableListWidget",
                 "map" => "$name.parameters",
                 "default" => "{}"
-            ],
-            "config" => [
+            ),
+            "config" => array(
                 "icon" => "gear",
                 "widget" => "PhpDebugBar.Widgets.VariableListWidget",
                 "map" => "$name.config",
                 "default" => "{}"
-            ],
-            "requirements" => [
+            ),
+            "requirements" => array(
                 "icon" => "file-o ",
                 "widget" => "PhpDebugBar.Widgets.ListWidget",
                 "map" => "$name.requirements",
                 "default" => "{}"
-            ],
-            'templates' => [
+            ),
+            'templates' => array(
                 'icon' => 'edit',
                 'widget' => 'PhpDebugBar.Widgets.ListWidget',
                 'map' => "$name.templates",
                 'default' => '{}'
-            ]
-        ];
+            )
+        );
 
         if (!empty(self::$debug)) {
-            $widgets["debug"] = [
+            $widgets["debug"] = array(
                 "icon" => "list-alt",
                 "widget" => "PhpDebugBar.Widgets.ListWidget",
                 "map" => "$name.debug",
                 "default" => "[]"
-            ];
-            $widgets["debug:badge"] = [
+            );
+            $widgets["debug:badge"] = array(
                 "map" => "$name.debugcount",
                 "default" => "null"
-            ];
+            );
         }
 
         return $widgets;
@@ -251,11 +251,11 @@ class DebugBarSilverStripeCollector extends DataCollector implements Renderable,
      */
     public function getAssets()
     {
-        return [
+        return array(
             'base_path' => '/' . DEBUGBAR_DIR . '/javascript',
             'base_url' => DEBUGBAR_DIR . '/javascript',
-            'css' => [],
+            'css' => array(),
             'js' => 'widgets.js',
-        ];
+        );
     }
 }

--- a/code/thirdparty/JdornSqlFormatter.php
+++ b/code/thirdparty/JdornSqlFormatter.php
@@ -33,7 +33,7 @@ class JdornSqlFormatter
     const TOKEN_VALUE = 1;
 
     // Reserved words (for syntax highlighting)
-    protected static $reserved = [
+    protected static $reserved = array(
         'ACCESSIBLE', 'ACTION', 'AGAINST', 'AGGREGATE', 'ALGORITHM', 'ALL', 'ALTER',
         'ANALYSE', 'ANALYZE', 'AS', 'ASC',
         'AUTOCOMMIT', 'AUTO_INCREMENT', 'BACKUP', 'BEGIN', 'BETWEEN', 'BINLOG', 'BOTH',
@@ -82,19 +82,19 @@ class JdornSqlFormatter
         'TRUNCATE', 'TYPE', 'TYPES', 'UNCOMMITTED', 'UNIQUE', 'UNLOCK', 'UNSIGNED',
         'USAGE', 'USE', 'USING', 'VARIABLES',
         'VIEW', 'WHEN', 'WITH', 'WORK', 'WRITE', 'YEAR_MONTH'
-    ];
+    );
     // For SQL formatting
     // These keywords will all be on their own line
-    protected static $reserved_toplevel = [
+    protected static $reserved_toplevel = array(
         'SELECT', 'FROM', 'WHERE', 'SET', 'ORDER BY', 'GROUP BY', 'LIMIT', 'DROP',
         'VALUES', 'UPDATE', 'HAVING', 'ADD', 'AFTER', 'ALTER TABLE', 'DELETE FROM',
         'UNION ALL', 'UNION', 'EXCEPT', 'INTERSECT'
-    ];
-    protected static $reserved_newline = [
+    );
+    protected static $reserved_newline = array(
         'LEFT OUTER JOIN', 'RIGHT OUTER JOIN', 'LEFT JOIN', 'RIGHT JOIN', 'OUTER JOIN',
         'INNER JOIN', 'JOIN', 'XOR', 'OR', 'AND'
-    ];
-    protected static $functions = [
+    );
+    protected static $functions = array(
         'ABS', 'ACOS', 'ADDDATE', 'ADDTIME', 'AES_DECRYPT', 'AES_ENCRYPT', 'AREA',
         'ASBINARY', 'ASCII', 'ASIN', 'ASTEXT', 'ATAN', 'ATAN2',
         'AVG', 'BDMPOLYFROMTEXT', 'BDMPOLYFROMWKB', 'BDPOLYFROMTEXT', 'BDPOLYFROMWKB',
@@ -147,12 +147,12 @@ class JdornSqlFormatter
         'UPDATEXML', 'UPPER', 'USER', 'UTC_DATE', 'UTC_TIME', 'UTC_TIMESTAMP',
         'UUID', 'VARIANCE', 'VAR_POP', 'VAR_SAMP', 'VERSION', 'WEEK', 'WEEKDAY',
         'WEEKOFYEAR', 'WITHIN', 'X', 'Y', 'YEAR', 'YEARWEEK'
-    ];
+    );
     // Punctuation that can be used as a boundary between other tokens
-    protected static $boundaries = [
+    protected static $boundaries = array(
         ',', ';', ':', ')', '(', '.', '=', '<',
         '>', '+', '-', '*', '/', '!', '^', '%', '|', '&', '#'
-    ];
+    );
     // For HTML syntax highlighting
     // Styles applied to different token types
     public static $quote_attributes          = 'style="color: blue;"';
@@ -195,7 +195,7 @@ class JdornSqlFormatter
     // Cache variables
     // Only tokens shorter than this size will be cached.  Somewhere between 10 and 20 seems to work well for most cases.
     public static $max_cachekey_size = 15;
-    protected static $token_cache    = [];
+    protected static $token_cache    = array();
     protected static $cache_hits     = 0;
     protected static $cache_misses   = 0;
 
@@ -205,12 +205,12 @@ class JdornSqlFormatter
      */
     public static function getCacheStats()
     {
-        return [
+        return array(
             'hits' => self::$cache_hits,
             'misses' => self::$cache_misses,
             'entries' => count(self::$token_cache),
             'size' => strlen(serialize(self::$token_cache))
-        ];
+        );
     }
 
     /**
@@ -228,20 +228,20 @@ class JdornSqlFormatter
 
         // Set up regular expressions
         self::$regex_boundaries        = '('.implode('|',
-                array_map([__CLASS__, 'quote_regex'], self::$boundaries)).')';
+                array_map(array(__CLASS__, 'quote_regex'), self::$boundaries)).')';
         self::$regex_reserved          = '('.implode('|',
-                array_map([__CLASS__, 'quote_regex'], self::$reserved)).')';
+                array_map(array(__CLASS__, 'quote_regex'), self::$reserved)).')';
         self::$regex_reserved_toplevel = str_replace(' ', '\\s+',
             '('.implode('|',
-                array_map([__CLASS__, 'quote_regex'],
+                array_map(array(__CLASS__, 'quote_regex'),
                     self::$reserved_toplevel)).')');
         self::$regex_reserved_newline  = str_replace(' ', '\\s+',
             '('.implode('|',
-                array_map([__CLASS__, 'quote_regex'],
+                array_map(array(__CLASS__, 'quote_regex'),
                     self::$reserved_newline)).')');
 
         self::$regex_function = '('.implode('|',
-                array_map([__CLASS__, 'quote_regex'], self::$functions)).')';
+                array_map(array(__CLASS__, 'quote_regex'), self::$functions)).')';
 
         self::$init = true;
     }
@@ -259,10 +259,10 @@ class JdornSqlFormatter
     {
         // Whitespace
         if (preg_match('/^\s+/', $string, $matches)) {
-            return [
+            return array(
                 self::TOKEN_VALUE => $matches[0],
                 self::TOKEN_TYPE => self::TOKEN_TYPE_WHITESPACE
-            ];
+            );
         }
 
         // Comment
@@ -281,30 +281,30 @@ class JdornSqlFormatter
                 $last = strlen($string);
             }
 
-            return [
+            return array(
                 self::TOKEN_VALUE => substr($string, 0, $last),
                 self::TOKEN_TYPE => $type
-            ];
+            );
         }
 
         // Quoted String
         if ($string[0] === '"' || $string[0] === '\'' || $string[0] === '`' || $string[0]
             === '[') {
-            $return = [
+            $return = array(
                 self::TOKEN_TYPE => (($string[0] === '`' || $string[0] === '[') ? self::TOKEN_TYPE_BACKTICK_QUOTE
                         : self::TOKEN_TYPE_QUOTE),
                 self::TOKEN_VALUE => self::getQuotedString($string)
-            ];
+            );
 
             return $return;
         }
 
         // User-defined Variable
         if (($string[0] === '@' || $string[0] === ':') && isset($string[1])) {
-            $ret = [
+            $ret = array(
                 self::TOKEN_VALUE => null,
                 self::TOKEN_TYPE => self::TOKEN_TYPE_VARIABLE
-            ];
+            );
 
             // If the variable name is quoted
             if ($string[1] === '"' || $string[1] === '\'' || $string[1] === '`') {
@@ -326,18 +326,18 @@ class JdornSqlFormatter
         // Number (decimal, binary, or hex)
         if (preg_match('/^([0-9]+(\.[0-9]+)?|0x[0-9a-fA-F]+|0b[01]+)($|\s|"\'`|'.self::$regex_boundaries.')/',
                 $string, $matches)) {
-            return [
+            return array(
                 self::TOKEN_VALUE => $matches[1],
                 self::TOKEN_TYPE => self::TOKEN_TYPE_NUMBER
-            ];
+            );
         }
 
         // Boundary Character (punctuation and symbols)
         if (preg_match('/^('.self::$regex_boundaries.')/', $string, $matches)) {
-            return [
+            return array(
                 self::TOKEN_VALUE => $matches[1],
                 self::TOKEN_TYPE => self::TOKEN_TYPE_BOUNDARY
-            ];
+            );
         }
 
         // A reserved word cannot be preceded by a '.'
@@ -348,26 +348,26 @@ class JdornSqlFormatter
             // Top Level Reserved Word
             if (preg_match('/^('.self::$regex_reserved_toplevel.')($|\s|'.self::$regex_boundaries.')/',
                     $upper, $matches)) {
-                return [
+                return array(
                     self::TOKEN_TYPE => self::TOKEN_TYPE_RESERVED_TOPLEVEL,
                     self::TOKEN_VALUE => substr($string, 0, strlen($matches[1]))
-                ];
+                );
             }
             // Newline Reserved Word
             if (preg_match('/^('.self::$regex_reserved_newline.')($|\s|'.self::$regex_boundaries.')/',
                     $upper, $matches)) {
-                return [
+                return array(
                     self::TOKEN_TYPE => self::TOKEN_TYPE_RESERVED_NEWLINE,
                     self::TOKEN_VALUE => substr($string, 0, strlen($matches[1]))
-                ];
+                );
             }
             // Other Reserved Word
             if (preg_match('/^('.self::$regex_reserved.')($|\s|'.self::$regex_boundaries.')/',
                     $upper, $matches)) {
-                return [
+                return array(
                     self::TOKEN_TYPE => self::TOKEN_TYPE_RESERVED,
                     self::TOKEN_VALUE => substr($string, 0, strlen($matches[1]))
-                ];
+                );
             }
         }
 
@@ -377,20 +377,20 @@ class JdornSqlFormatter
         // function
         if (preg_match('/^('.self::$regex_function.'[(]|\s|[)])/', $upper,
                 $matches)) {
-            return [
+            return array(
                 self::TOKEN_TYPE => self::TOKEN_TYPE_RESERVED,
                 self::TOKEN_VALUE => substr($string, 0, strlen($matches[1]) - 1)
-            ];
+            );
         }
 
         // Non reserved word
         preg_match('/^(.*?)($|\s|["\'`]|'.self::$regex_boundaries.')/', $string,
             $matches);
 
-        return [
+        return array(
             self::TOKEN_VALUE => $matches[1],
             self::TOKEN_TYPE => self::TOKEN_TYPE_WORD
-        ];
+        );
     }
 
     protected static function getQuotedString($string)
@@ -422,7 +422,7 @@ class JdornSqlFormatter
     {
         self::init();
 
-        $tokens = [];
+        $tokens = array();
 
         // Used for debugging if there is an error while tokenizing the string
         $original_length = strlen($string);
@@ -438,10 +438,10 @@ class JdornSqlFormatter
         while ($current_length) {
             // If the string stopped shrinking, there was a problem
             if ($old_string_len <= $current_length) {
-                $tokens[] = [
+                $tokens[] = array(
                     self::TOKEN_VALUE => $string,
                     self::TOKEN_TYPE => self::TOKEN_TYPE_ERROR
-                ];
+                );
 
                 return $tokens;
             }
@@ -504,7 +504,7 @@ class JdornSqlFormatter
         $inline_parentheses      = false;
         $increase_special_indent = false;
         $increase_block_indent   = false;
-        $indent_types            = [];
+        $indent_types            = array();
         $added_newline           = false;
         $inline_count            = 0;
         $inline_indented         = false;
@@ -514,7 +514,7 @@ class JdornSqlFormatter
         $original_tokens = self::tokenize($string);
 
         // Remove existing whitespace
-        $tokens = [];
+        $tokens = array();
         foreach ($original_tokens as $i => $token) {
             if ($token[self::TOKEN_TYPE] !== self::TOKEN_TYPE_WHITESPACE) {
                 $token['i'] = $i;
@@ -831,7 +831,7 @@ class JdornSqlFormatter
      */
     public static function splitQuery($string)
     {
-        $queries       = [];
+        $queries       = array();
         $current_query = '';
         $empty         = true;
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4.8",
+        "php": ">=5.3.3",
         "silverstripe/framework": "~3.2",
         "silverstripe/siteconfig": "~3.2",
         "maximebf/debugbar": "^1.13"

--- a/tests/DebugBarControllerExtensionTest.php
+++ b/tests/DebugBarControllerExtensionTest.php
@@ -2,9 +2,9 @@
 
 class DebugBarControllerExtensionTest extends FunctionalTest
 {
-    protected $requiredExtensions = [
-        'Controller' => ['DebugBarControllerExtension']
-    ];
+    protected $requiredExtensions = array(
+        'Controller' => array('DebugBarControllerExtension')
+    );
 
     /**
      * @var Controller

--- a/tests/DebugBarDatabaseCollectorTest.php
+++ b/tests/DebugBarDatabaseCollectorTest.php
@@ -49,30 +49,30 @@ class DebugBarDatabaseCollectorTest extends SapphireTest
 
     public function testGetWidgets()
     {
-        $expected = [
-            'database' => [
+        $expected = array(
+            'database' => array(
                 'icon' => 'inbox',
                 'widget' => 'PhpDebugBar.Widgets.SQLQueriesWidget',
                 'map' => 'db',
                 'default' => '[]'
-            ],
-            'database:badge' => [
+            ),
+            'database:badge' => array(
                 'map' => 'db.nb_statements',
                 'default' => 0
-            ]
-        ];
+            )
+        );
 
         $this->assertSame($expected, $this->collector->getWidgets());
     }
 
     public function testGetAssets()
     {
-        $expected = [
+        $expected = array(
             'base_path' => '/debugbar/javascript',
             'base_url' => 'debugbar/javascript',
             'css' => 'sqlqueries/widget.css',
             'js' => 'sqlqueries/widget.js'
-        ];
+        );
 
         $this->assertSame($expected, $this->collector->getAssets());
     }

--- a/tests/DebugBarDatabaseNewProxyTest.php
+++ b/tests/DebugBarDatabaseNewProxyTest.php
@@ -51,7 +51,7 @@ class DebugBarDatabaseNewProxyTest extends SapphireTest
      */
     public function testMethodsAreProxiedToRealConnection()
     {
-        $proxyMethods = [
+        $proxyMethods = array(
             'addslashes',
             'alterTable',
             'comparisonClause',
@@ -82,7 +82,7 @@ class DebugBarDatabaseNewProxyTest extends SapphireTest
             'random',
             'searchEngine',
             'supportsCollations',
-        ];
+        );
 
         $mockConnection = $this->getMockBuilder('MySQLDatabase')->setMethods($proxyMethods)->getMock();
         $proxy = new DebugBarDatabaseNewProxy($mockConnection);

--- a/tests/DebugBarLogWriterTest.php
+++ b/tests/DebugBarLogWriterTest.php
@@ -39,7 +39,7 @@ class DebugBarLogWriterTest extends SapphireTest
 
     public function testFactory()
     {
-        $instance = DebugBarLogWriter::factory(['foo']);
+        $instance = DebugBarLogWriter::factory(array('foo'));
         $this->assertInstanceOf('DebugBarLogWriter', $instance);
     }
 

--- a/tests/DebugBarSilverStripeCollectorTest.php
+++ b/tests/DebugBarSilverStripeCollectorTest.php
@@ -54,11 +54,11 @@ class DebugBarSilverStripeCollectorTest extends SapphireTest
             new SS_HTTPRequest(
                 'GET',
                 '/',
-                ['getvar' => 'value', 'foo' => 'bar'],
-                ['postvar' => 'value', 'bar' => 'baz']
+                array('getvar' => 'value', 'foo' => 'bar'),
+                array('postvar' => 'value', 'bar' => 'baz')
             )
         );
-        $controller->getRequest()->setRouteParams(['something' => 'here']);
+        $controller->getRequest()->setRouteParams(array('something' => 'here'));
 
         $this->collector->setController($controller);
         $this->assertSame($controller, $this->collector->getController());
@@ -92,59 +92,59 @@ class DebugBarSilverStripeCollectorTest extends SapphireTest
         $result['version']['tooltip'] = 'Stub';
         $result['locale']['tooltip'] = 'Stub';
 
-        $expected = [
-            'user' => [
+        $expected = array(
+            'user' => array(
                 'icon' => 'user',
                 'tooltip' => 'Current member',
                 'default' => '',
-            ],
-            'version' => [
+            ),
+            'version' => array(
                 'icon' => 'desktop',
                 'tooltip' => 'Stub',
                 'default' => '',
-            ],
-            'locale' => [
+            ),
+            'locale' => array(
                 'icon' => 'globe',
                 'tooltip' => 'Stub',
                 'default' => '',
-            ],
-            'session' => [
+            ),
+            'session' => array(
                 'icon' => 'archive',
                 'widget' => 'PhpDebugBar.Widgets.VariableListWidget',
                 'map' => 'silverstripe.session',
                 'default' => '{}',
-            ],
-            'cookies' => [
+            ),
+            'cookies' => array(
                 'icon' => 'asterisk',
                 'widget' => 'PhpDebugBar.Widgets.VariableListWidget',
                 'map' => 'silverstripe.cookies',
                 'default' => '{}',
-            ],
-            'parameters' => [
+            ),
+            'parameters' => array(
                 'icon' => 'arrow-right',
                 'widget' => 'PhpDebugBar.Widgets.VariableListWidget',
                 'map' => 'silverstripe.parameters',
                 'default' => '{}',
-            ],
-            'config' => [
+            ),
+            'config' => array(
                 'icon' => 'gear',
                 'widget' => 'PhpDebugBar.Widgets.VariableListWidget',
                 'map' => 'silverstripe.config',
                 'default' => '{}',
-            ],
-            'requirements' => [
+            ),
+            'requirements' => array(
                 'icon' => 'file-o ',
                 'widget' => 'PhpDebugBar.Widgets.ListWidget',
                 'map' => 'silverstripe.requirements',
                 'default' => '{}',
-            ],
-            'templates' => [
+            ),
+            'templates' => array(
                 'icon' => 'edit',
                 'widget' => 'PhpDebugBar.Widgets.ListWidget',
                 'map' => "silverstripe.templates",
                 'default' => '{}'
-            ]
-        ];
+            )
+        );
 
         //TODO: expected should reflect the dynamic data for the current user
 //        $this->assertSame($expected, $result);
@@ -152,12 +152,12 @@ class DebugBarSilverStripeCollectorTest extends SapphireTest
 
     public function testGetAssets()
     {
-        $expected = [
+        $expected = array(
             'base_path' => '/debugbar/javascript',
             'base_url' => 'debugbar/javascript',
-            'css' => [],
+            'css' => array(),
             'js' => 'widgets.js',
-        ];
+        );
         $this->assertSame($expected, $this->collector->getAssets());
     }
 

--- a/tests/DebugBarSilverStripeCollectorTest.php
+++ b/tests/DebugBarSilverStripeCollectorTest.php
@@ -91,6 +91,7 @@ class DebugBarSilverStripeCollectorTest extends SapphireTest
         // Stub out the dynamic data
         $result['version']['tooltip'] = 'Stub';
         $result['locale']['tooltip'] = 'Stub';
+        $result['user']['tooltip'] = 'Current member';
 
         $expected = array(
             'user' => array(
@@ -146,8 +147,7 @@ class DebugBarSilverStripeCollectorTest extends SapphireTest
             )
         );
 
-        //TODO: expected should reflect the dynamic data for the current user
-//        $this->assertSame($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     public function testGetAssets()

--- a/tests/DebugBarTest.php
+++ b/tests/DebugBarTest.php
@@ -33,7 +33,7 @@ class DebugBarTest extends SapphireTest
         }
 
         $class = get_class($conn);
-        $this->assertContains($class, ['DebugBarDatabaseNewProxy', 'DebugBarDatabaseProxy']);
+        $this->assertContains($class, array('DebugBarDatabaseNewProxy', 'DebugBarDatabaseProxy'));
     }
 
     public function testLHelper()
@@ -90,26 +90,26 @@ class DebugBarTest extends SapphireTest
      */
     public function whyDisabledProvider()
     {
-        return [
-            [
+        return array(
+            array(
                 function () {
                     Director::set_environment_type('live');
                 },
                 'Not in dev mode'
-            ],
-            [
+            ),
+            array(
                 function () {
                     Config::inst()->update('DebugBar', 'disabled', true);
                 },
                 'Disabled by a constant or configuration'
-            ],
-            [
+            ),
+            array(
                 function () {
                     // no-op
                 },
                 'In CLI mode'
-            ]
-        ];
+            )
+        );
     }
 
     public function testNotLocalIp()


### PR DESCRIPTION
@lekoala we've enabled PHP5.3 support on this module by changing all arrays to traditional syntax for SS5.3 support. Dropped the required php version to 5.3 in composer.json too.

Also fixed the failing unit test in DebugBarSilverStripeCollectorTest::testGetWidgets()