### PR TITLE
NEW Show all templates rendered when not cached

### DIFF
--- a/_config/debugbar.yml
+++ b/_config/debugbar.yml
@@ -37,6 +37,8 @@ Injector:
     properties:
       filters:
         - '%$DebugBarRequestFilter'
+  SSTemplateParser:
+    class: DebugBarTemplateParserProxy
 LeftAndMain:
   extensions:
     - DebugBarLeftAndMainExtension

--- a/code/DebugBarSilverStripeCollector.php
+++ b/code/DebugBarSilverStripeCollector.php
@@ -30,21 +30,25 @@ class DebugBarSilverStripeCollector extends DataCollector implements Renderable,
 
     /**
      * Returns the names of all the templates rendered.
+     *
      * @return array
      */
     public static function getTemplateData()
     {
-        $result = array();
-        $controller = self::$controller;
-        if ($controller) {
-            /** @var SSViewer $viewer */
-            if ($viewer = $controller->getViewer($controller->getAction())) {
-                foreach ($viewer->templates() as $key => $val) {
-                    $result[] = str_ireplace(BASE_PATH, '', $val);
-                }
-            }
+        if (DebugBarTemplateParserProxy::getCached()) {
+            return array(
+                'templates' => array(
+                    'NOTE: Rendered templates will not display when cached, please flush to view the list.'
+                ),
+                'count' => '-'
+            );
         }
-        return $result;
+
+        $templates = DebugBarTemplateParserProxy::getTemplatesUsed();
+        return array(
+            'templates' => $templates,
+            'count' => count($templates)
+        );
     }
 
     public static function getRequirementsData()
@@ -225,8 +229,12 @@ class DebugBarSilverStripeCollector extends DataCollector implements Renderable,
             'templates' => array(
                 'icon' => 'edit',
                 'widget' => 'PhpDebugBar.Widgets.ListWidget',
-                'map' => "$name.templates",
+                'map' => "$name.templates.templates",
                 'default' => '{}'
+            ),
+            'templates:badge' => array(
+                'map' => "$name.templates.count",
+                'default' => 0
             )
         );
 

--- a/code/DebugBarTemplateParserProxy.php
+++ b/code/DebugBarTemplateParserProxy.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * The template parser proxy will monitor the templates that are used during a page request. Since the
+ * use of the template parser is behind cache checks, this will only execute during a cache flush.
+ */
+class DebugBarTemplateParserProxy extends SSTemplateParser
+{
+    /**
+     * Tracks all templates used in the current request
+     *
+     * @var array
+     */
+    protected static $allTemplates = array();
+
+    /**
+     * Whether the class has been used, meaning whether the page has been cached
+     *
+     * @var boolean
+     */
+    protected static $cached = true;
+
+    /**
+     * Overloaded to track all templates used in the current request
+     *
+     * {@inheritDoc}
+     */
+    public function compileString($string, $templateName = '', $includeDebuggingComments = false, $topTemplate = true)
+    {
+        static::$cached = false;
+
+        if (DebugBar::config()->force_proxy) {
+            static::trackTemplateUsed($templateName);
+        }
+
+        return parent::compileString($string, $templateName, $includeDebuggingComments, $topTemplate);
+    }
+
+    /**
+     * Get the templates used in the current request and the number of times they were called
+     *
+     * @return array
+     */
+    public static function getTemplatesUsed()
+    {
+        return static::$allTemplates;
+    }
+
+    /**
+     * Determines whether the template rendering is cached or not based on whether the compileString method has been
+     * called at any point.
+     *
+     * @return bool
+     */
+    public static function getCached()
+    {
+        return static::$cached;
+    }
+
+    /**
+     * Remove the base path from a template file path and track its use
+     *
+     * @param string $templateName
+     */
+    protected static function trackTemplateUsed($templateName)
+    {
+        static::$allTemplates[] = str_ireplace(BASE_PATH, '', $templateName);
+    }
+}

--- a/tests/DebugBarSilverStripeCollectorTest.php
+++ b/tests/DebugBarSilverStripeCollectorTest.php
@@ -142,8 +142,12 @@ class DebugBarSilverStripeCollectorTest extends SapphireTest
             'templates' => array(
                 'icon' => 'edit',
                 'widget' => 'PhpDebugBar.Widgets.ListWidget',
-                'map' => "silverstripe.templates",
+                'map' => "silverstripe.templates.templates",
                 'default' => '{}'
+            ),
+            'templates:badge' => array(
+                'map' => 'silverstripe.templates.count',
+                'default' => 0
             )
         );
 
@@ -162,19 +166,18 @@ class DebugBarSilverStripeCollectorTest extends SapphireTest
     }
 
     /**
-     * Test that at least one template is returned when visiting the home page
+     * Test that a message is returned when templates are cached. For retrieval of template info, see
+     * {@link DebugBarTemplateParserProxyTest} for examples.
+     *
+     * Note that the template proxy will register as cached by default until it gets used the first time.
      */
     public function testGetTemplateData()
     {
-        $controller = new Controller;
-        $controller->init();
-        $controller->setRequest(
-            new SS_HTTPRequest(
-                'GET',
-                '/'
-            )
+        $result = DebugBarSilverStripeCollector::getTemplateData();
+        $this->assertContains(
+            'NOTE: Rendered templates will not display when cached',
+            array_pop($result['templates'])
         );
-        $this->collector->setController($controller);
-        $this->assertGreaterThan(1, count($this->collector->getTemplateData()));
+        $this->assertSame('-', $result['count']);
     }
 }

--- a/tests/DebugBarTemplateParserProxyTest.php
+++ b/tests/DebugBarTemplateParserProxyTest.php
@@ -1,0 +1,30 @@
+<?php
+
+class DebugBarTemplateParserProxyTest extends FunctionalTest
+{
+    public function testOverloadsSSTemplateParser()
+    {
+        $templateParser = Injector::inst()->get('SSTemplateParser');
+        $this->assertInstanceOf('DebugBarTemplateParserProxy', $templateParser);
+        $this->assertInstanceOf('TemplateParser', $templateParser);
+    }
+
+    public function testEmptyTemplatesAndCachedByDefault()
+    {
+        $this->assertEmpty(DebugBarTemplateParserProxy::getTemplatesUsed());
+        $this->assertTrue(DebugBarTemplateParserProxy::getCached());
+    }
+
+    public function testTrackTemplatesUsed()
+    {
+        $this->get('/Security/login?flush=1');
+
+        $templates = DebugBarTemplateParserProxy::getTemplatesUsed();
+
+        $this->assertNotEmpty($templates);
+        $this->assertContains('/framework/templates/Includes/Form.ss', $templates);
+        $this->assertContains('/framework/templates/forms/TextField.ss', $templates);
+
+        $this->assertFalse(DebugBarTemplateParserProxy::getCached());
+    }
+}


### PR DESCRIPTION
When cached, a message will be shown saying that templates will be shown when flushed.

## On flush

![image](https://user-images.githubusercontent.com/5170590/27890523-4d56e5de-6247-11e7-8b3f-1b8576114c04.png)

## Without flush/when cached

![image](https://user-images.githubusercontent.com/5170590/27890532-58fa3350-6247-11e7-8b19-528e3a532fae.png)

---

I'd really like to be able to do this while cached too, but none of the framework's classes that would be useful are injectable or overloadable. This may need to be a SS4 thing.