### PR TITLE
Disable codecov commit status notifications

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,1 +1,6 @@
 comment: off
+coverage:
+  status:
+    project: off
+    patch: off
+


### PR DESCRIPTION
This info is useful to know, but perhaps not on every pull request. By failing CI checks it is maybe a little misleading as to the mergability of a PR.