### PR TITLE
FIX Errors in requirements and message collector in CMS, and badge alignment

### DIFF
--- a/assets/debugbar.css
+++ b/assets/debugbar.css
@@ -157,6 +157,7 @@ a.phpdebugbar-tab.phpdebugbar-active span.phpdebugbar-badge {
   a.phpdebugbar-tab span.phpdebugbar-badge {
     display: none;
     margin-left: 5px;
+    float: right;
     font-size: 11px;
     line-height: 14px;
     padding: 1px 7px;

--- a/code/Collector/DatabaseCollector.php
+++ b/code/Collector/DatabaseCollector.php
@@ -7,7 +7,9 @@ use DebugBar\DataCollector\DataCollector;
 use DebugBar\DataCollector\Renderable;
 use DebugBar\DataCollector\TimeDataCollector as BaseTimeDataCollector;
 use LeKoala\DebugBar\DebugBar;
+use Psr\Log\LoggerInterface;
 use SilverStripe\Core\Config\Config;
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\ORM\DB;
 
 /**
@@ -39,13 +41,11 @@ class DatabaseCollector extends DataCollector implements Renderable, AssetProvid
         // Check for excessive number of queries
         $dbQueryWarningLevel = DebugBar::config()->warn_query_limit;
         if ($dbQueryWarningLevel && $data['nb_statements'] > $dbQueryWarningLevel) {
-            DebugBar::getDebugBar()
-                ->getCollector('messages')
-                ->addMessage(
+            Injector::inst()->get(LoggerInterface::class)
+                ->addWarning(
                     'This page ran more than ' . $dbQueryWarningLevel . ' database queries. You could reduce this by '
                     . 'implementing caching. For more information, <a href="https://docs.silverstripe.org/en/'
-                    . 'developer_guides/performance/" target="_blank">click here.</a>',
-                    'warning'
+                    . 'developer_guides/performance/" target="_blank">click here.</a>'
                 );
         }
 

--- a/code/DebugBar.php
+++ b/code/DebugBar.php
@@ -201,7 +201,7 @@ class DebugBar
         }
         // If jQuery is already included, set to false
         $js = Requirements::backend()->getJavascript();
-        foreach ($js as $url) {
+        foreach ($js as $url => $args) {
             $name = basename($url);
             if ($name == 'jquery.js' || $name == 'jquery.min.js') {
                 $includeJquery = false;


### PR DESCRIPTION
This fixes a couple of errors when hitting `/admin/pages` since the Requirements API changed and we implemented a Monolog bridge instead of a collector for messages. It also fixes alignment for the number badges on the debug bar tabs.