### PR TITLE
Don't use FQN

### DIFF
--- a/_config/debugbar.yml
+++ b/_config/debugbar.yml
@@ -26,6 +26,8 @@ LeKoala\DebugBar\DebugBar:
   warn_request_time_seconds: 5.0
   # Ratio to divide the warning request time by to get the *warning* level
   warn_warning_ratio: 0.5
+  # Hide FQN in the database profiling tab
+  show_namespaces: false
 
 SilverStripe\Control\Director:
   rules:

--- a/code/Proxy/DatabaseProxy.php
+++ b/code/Proxy/DatabaseProxy.php
@@ -322,6 +322,10 @@ class DatabaseProxy extends Database
             }
 
             $name = $class;
+            if ($class && !DebugBar::config()->get('show_namespaces')) {
+                $nameArray = explode("\\", $class);
+                $name = array_pop($nameArray);
+            }
             if ($function) {
                 $name .= $type.$function;
             }

--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -29,6 +29,7 @@ LeKoala\DebugBar\DebugBar:
 | `warn_dbqueries_threshold_seconds` | int | Threshold (seconds) for how long a database query can run for before it will be shown as a warning |
 | `warn_request_time_seconds` | int | Threshold (seconds) for what constitutes a *dangerously* long page request (upper limit) |
 | `warn_warning_ratio` | float | Ratio to divide the warning request time by to get the *warning* level (default 0.5) |
+| `show_namespace` | bool | Show the fully qualified namespace in the Database tab when set to true. Defaults to false |
 
 ## Disabling the debug bar
 

--- a/tests/Collector/DatabaseCollectorTest.php
+++ b/tests/Collector/DatabaseCollectorTest.php
@@ -42,7 +42,7 @@ class DatabaseCollectorTest extends SapphireTest
         $statement = array_shift($result['statements']);
         $this->assertNotEmpty($statement['sql']);
         $this->assertEquals(1, $statement['is_success']);
-        $this->assertContains('SilverStripe\Dev\SapphireTest', $statement['source']);
+        $this->assertContains('SapphireTest', $statement['source']);
         $this->assertFalse($statement['warn']);
 
         // Deliberately low warning threshold


### PR DESCRIPTION
Using the FQN in the queries tab makes the trace interfere with other information and add unnecessary information. Removing the FQN in favour of UQN makes it more readable.