### PR TITLE
Add icons and colours to the message tab.

### DIFF
--- a/assets/widgets.css
+++ b/assets/widgets.css
@@ -4,15 +4,15 @@ ul.phpdebugbar-widgets-list {
   list-style: none;
   font-family: monospace;
 }
-  ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item {
-    padding: 3px 6px;
-    border-bottom: 1px solid #eee;
-    position: relative;
-    overflow: hidden;
-  }
-  ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item:hover {
-    background: #fafafa;
-  }
+ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item {
+  padding: 3px 6px;
+  border-bottom: 1px solid #eee;
+  position: relative;
+  overflow: hidden;
+}
+ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item:hover {
+  background: #fafafa;
+}
 
 /* -------------------------------------- */
 
@@ -20,96 +20,130 @@ div.phpdebugbar-widgets-messages {
   position: relative;
   height: 100%;
 }
-  div.phpdebugbar-widgets-messages div.phpdebugbar-widgets-list {
-    padding-bottom: 20px;
-  }
-  div.phpdebugbar-widgets-messages li.phpdebugbar-widgets-list-item span.phpdebugbar-widgets-value.phpdebugbar-widgets-warning:before {
-    font-family: PhpDebugbarFontAwesome;
-    content: "\f071";
-    margin-right: 8px;
-    font-size: 11px;
-    color: #ecb03d;
-  }
-  div.phpdebugbar-widgets-messages li.phpdebugbar-widgets-list-item span.phpdebugbar-widgets-value.phpdebugbar-widgets-error {
-    color: red;
-  }
-  div.phpdebugbar-widgets-messages li.phpdebugbar-widgets-list-item span.phpdebugbar-widgets-value.phpdebugbar-widgets-error:before {
-    font-family: PhpDebugbarFontAwesome;
-    content: "\f057";
-    margin-right: 8px;
-    font-size: 11px;
-    color: red;
-  }
-  div.phpdebugbar-widgets-messages li.phpdebugbar-widgets-list-item span.phpdebugbar-widgets-collector,
-  div.phpdebugbar-widgets-messages li.phpdebugbar-widgets-list-item span.phpdebugbar-widgets-label {
-    float: right;
-    font-size: 12px;
-    padding: 2px 4px;
-    color: #888;
-    margin: 0 2px;
-    text-decoration: none;
-    text-shadow: none;
-    background: none;
-    font-weight: normal;
-  }
-  div.phpdebugbar-widgets-messages li.phpdebugbar-widgets-list-item span.phpdebugbar-widgets-collector {
-    color: #555;
-    font-style: italic;
-  }
-  div.phpdebugbar-widgets-messages div.phpdebugbar-widgets-toolbar {
-    position: fixed;
-    bottom: 0;
-    width: 100%;
-    background: #fff;
-  }
-    div.phpdebugbar-widgets-messages div.phpdebugbar-widgets-toolbar input {
-      border: 0;
-      margin: 0;
-      margin-left: 7px;
-      width: 50%;
-      box-shadow: none;
-    }
-    div.phpdebugbar-widgets-messages div.phpdebugbar-widgets-toolbar input:focus {
-      outline: none;
-    }
-      div.phpdebugbar-widgets-messages div.phpdebugbar-widgets-toolbar a.phpdebugbar-widgets-filter {
-        float: right;
-        font-size: 12px;
-        padding: 2px 4px;
-        background: #005A92;
-        margin: 0 2px;
-        border-radius: 4px;
-        color: #fff;
-        text-decoration: none;
-      }
-      div.phpdebugbar-widgets-messages div.phpdebugbar-widgets-toolbar a.phpdebugbar-widgets-filter.phpdebugbar-widgets-excluded {
-        background: #eee;
-        color: #888;
-      }
+div.phpdebugbar-widgets-messages div.phpdebugbar-widgets-list {
+  padding-bottom: 20px;
+}
+span.phpdebugbar-widgets-value.phpdebugbar-widgets-warning:before {
+  font-family: PhpDebugbarFontAwesome;
+  content: "\f071";
+  margin-right: 8px;
+  font-size: 11px;
+  color: #f46b00;
+}
+
+span.phpdebugbar-widgets-value.phpdebugbar-widgets-info:before {
+  font-family: PhpDebugbarFontAwesome;
+  content: "\f05a";
+  margin-right: 8px;
+  font-size: 11px;
+  color: #0071c4;
+}
+
+span.phpdebugbar-widgets-value.phpdebugbar-widgets-alert:before {
+  font-family: PhpDebugbarFontAwesome;
+  content: "\f06a";
+  margin-right: 8px;
+  font-size: 11px;
+  color: #d30000;
+}
+
+span.phpdebugbar-widgets-value.phpdebugbar-widgets-debug:before {
+  font-family: PhpDebugbarFontAwesome;
+  content: "\f188";
+  margin-right: 8px;
+  font-size: 11px;
+  color: #3fa142;
+}
+
+span.phpdebugbar-widgets-value.phpdebugbar-widgets-notice:before {
+  font-family: PhpDebugbarFontAwesome;
+  content: "\f249";
+  margin-right: 8px;
+  font-size: 11px;
+  color: #0071c4;
+}
+
+div.phpdebugbar-widgets-messages li.phpdebugbar-widgets-list-item span.phpdebugbar-widgets-value.phpdebugbar-widgets-error {
+  color: #d30000;
+}
+
+span.phpdebugbar-widgets-value.phpdebugbar-widgets-error:before {
+  font-family: PhpDebugbarFontAwesome;
+  content: "\f057";
+  margin-right: 8px;
+  font-size: 11px;
+  color: #a94442;
+}
+div.phpdebugbar-widgets-messages li.phpdebugbar-widgets-list-item span.phpdebugbar-widgets-collector,
+div.phpdebugbar-widgets-messages li.phpdebugbar-widgets-list-item span.phpdebugbar-widgets-label {
+  float: right;
+  font-size: 12px;
+  padding: 2px 4px;
+  color: #888;
+  margin: 0 2px;
+  text-decoration: none;
+  text-shadow: none;
+  background: none;
+  font-weight: normal;
+}
+div.phpdebugbar-widgets-messages li.phpdebugbar-widgets-list-item span.phpdebugbar-widgets-collector {
+  color: #555;
+  font-style: italic;
+}
+div.phpdebugbar-widgets-messages div.phpdebugbar-widgets-toolbar {
+  position: fixed;
+  bottom: 0;
+  width: 100%;
+  background: #fff;
+}
+div.phpdebugbar-widgets-messages div.phpdebugbar-widgets-toolbar input {
+  border: 0;
+  margin: 0;
+  margin-left: 7px;
+  width: 50%;
+  box-shadow: none;
+}
+div.phpdebugbar-widgets-messages div.phpdebugbar-widgets-toolbar input:focus {
+  outline: none;
+}
+div.phpdebugbar-widgets-messages div.phpdebugbar-widgets-toolbar a.phpdebugbar-widgets-filter {
+  float: right;
+  font-size: 12px;
+  padding: 2px 4px;
+  background: #005A92;
+  margin: 0 2px;
+  border-radius: 4px;
+  color: #fff;
+  text-decoration: none;
+}
+div.phpdebugbar-widgets-messages div.phpdebugbar-widgets-toolbar a.phpdebugbar-widgets-filter.phpdebugbar-widgets-excluded {
+  background: #eee;
+  color: #888;
+}
 
 /* -------------------------------------- */
 
 dl.phpdebugbar-widgets-kvlist {
   margin: 0;
 }
-  dl.phpdebugbar-widgets-kvlist dt {
-    float: left;
-    width: 150px;
-    padding: 5px;
-    border-top: 1px solid #eee;
-    font-weight: bold;
-    clear: both;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-  dl.phpdebugbar-widgets-kvlist dd {
-    margin-left: 160px;
-    padding: 5px;
-    border-top: 1px solid #eee;
-    cursor: pointer;
-    min-height: 17px;
-  }
+dl.phpdebugbar-widgets-kvlist dt {
+  float: left;
+  width: 150px;
+  padding: 5px;
+  border-top: 1px solid #eee;
+  font-weight: bold;
+  clear: both;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+dl.phpdebugbar-widgets-kvlist dd {
+  margin-left: 160px;
+  padding: 5px;
+  border-top: 1px solid #eee;
+  cursor: pointer;
+  min-height: 17px;
+}
 
 /* -------------------------------------- */
 
@@ -124,86 +158,86 @@ ul.phpdebugbar-widgets-timeline {
   padding: 0;
   list-style: none;
 }
-  ul.phpdebugbar-widgets-timeline .phpdebugbar-widgets-measure {
-    height: 20px;
-    position: relative;
-    border-bottom: 1px solid #eee;
-    display: block;
-  }
-  ul.phpdebugbar-widgets-timeline li:hover {
-    background: #fafafa;
-  }
-    ul.phpdebugbar-widgets-timeline li span.phpdebugbar-widgets-label,
-    ul.phpdebugbar-widgets-timeline li span.phpdebugbar-widgets-collector {
-      position: absolute;
-      font-size: 12px;
-      font-family: monospace;
-      color: #555;
-      top: 4px;
-      left: 5px;
-      background: none;
-      text-shadow: none;
-      font-weight: normal;
-      white-space: pre;
-    }
-    ul.phpdebugbar-widgets-timeline li span.phpdebugbar-widgets-collector {
-      left: initial;
-      right: 5px;
-    }
-    ul.phpdebugbar-widgets-timeline li span.phpdebugbar-widgets-value {
-      display: block;
-      position: absolute;
-      height: 10px;
-      background: #32B8E4;
-      top: 5px;
-      border-radius: 2px;
-      min-width: 1px;
-    }
-    ul.phpdebugbar-widgets-timeline table.phpdebugbar-widgets-params {
-      display: none;
-      width: 70%;
-      margin: 10px;
-      border: 1px solid #ddd;
-      font-family: monospace;
-      border-collapse: collapse;
-    }
-      ul.phpdebugbar-widgets-timeline table.phpdebugbar-widgets-params td {
-        border: 1px solid #ddd;
-        padding: 0 5px;
-      }
-      ul.phpdebugbar-widgets-timeline table.phpdebugbar-widgets-params .phpdebugbar-widgets-name {
-        width: 20%;
-        font-weight: bold;
-      }
+ul.phpdebugbar-widgets-timeline .phpdebugbar-widgets-measure {
+  height: 20px;
+  position: relative;
+  border-bottom: 1px solid #eee;
+  display: block;
+}
+ul.phpdebugbar-widgets-timeline li:hover {
+  background: #fafafa;
+}
+ul.phpdebugbar-widgets-timeline li span.phpdebugbar-widgets-label,
+ul.phpdebugbar-widgets-timeline li span.phpdebugbar-widgets-collector {
+  position: absolute;
+  font-size: 12px;
+  font-family: monospace;
+  color: #555;
+  top: 4px;
+  left: 5px;
+  background: none;
+  text-shadow: none;
+  font-weight: normal;
+  white-space: pre;
+}
+ul.phpdebugbar-widgets-timeline li span.phpdebugbar-widgets-collector {
+  left: initial;
+  right: 5px;
+}
+ul.phpdebugbar-widgets-timeline li span.phpdebugbar-widgets-value {
+  display: block;
+  position: absolute;
+  height: 10px;
+  background: #32B8E4;
+  top: 5px;
+  border-radius: 2px;
+  min-width: 1px;
+}
+ul.phpdebugbar-widgets-timeline table.phpdebugbar-widgets-params {
+  display: none;
+  width: 70%;
+  margin: 10px;
+  border: 1px solid #ddd;
+  font-family: monospace;
+  border-collapse: collapse;
+}
+ul.phpdebugbar-widgets-timeline table.phpdebugbar-widgets-params td {
+  border: 1px solid #ddd;
+  padding: 0 5px;
+}
+ul.phpdebugbar-widgets-timeline table.phpdebugbar-widgets-params .phpdebugbar-widgets-name {
+  width: 20%;
+  font-weight: bold;
+}
 
 /* -------------------------------------- */
 
 div.phpdebugbar-widgets-exceptions li.phpdebugbar-widgets-list-item {
   cursor: pointer;
 }
-  div.phpdebugbar-widgets-exceptions li.phpdebugbar-widgets-list-item span.phpdebugbar-widgets-message {
-    display: block;
-    color: red;
-  }
+div.phpdebugbar-widgets-exceptions li.phpdebugbar-widgets-list-item span.phpdebugbar-widgets-message {
+  display: block;
+  color: red;
+}
 
-  div.phpdebugbar-widgets-exceptions li.phpdebugbar-widgets-list-item span.phpdebugbar-widgets-filename {
-    display: block;
-    font-style: italic;
-    color: #555;
-  }
+div.phpdebugbar-widgets-exceptions li.phpdebugbar-widgets-list-item span.phpdebugbar-widgets-filename {
+  display: block;
+  font-style: italic;
+  color: #555;
+}
 
-  div.phpdebugbar-widgets-exceptions li.phpdebugbar-widgets-list-item span.phpdebugbar-widgets-type {
-    display: block;
-    position: absolute;
-    right: 4px;
-    top: 4px;
-    font-weight: bold;
-  }
+div.phpdebugbar-widgets-exceptions li.phpdebugbar-widgets-list-item span.phpdebugbar-widgets-type {
+  display: block;
+  position: absolute;
+  right: 4px;
+  top: 4px;
+  font-weight: bold;
+}
 
-  div.phpdebugbar-widgets-exceptions li.phpdebugbar-widgets-list-item pre.phpdebugbar-widgets-file {
-    display: none;
-    margin: 10px;
-    padding: 5px;
-    border: 1px solid #ddd;
-    font-family: monospace;
-  }
+div.phpdebugbar-widgets-exceptions li.phpdebugbar-widgets-list-item pre.phpdebugbar-widgets-file {
+  display: none;
+  margin: 10px;
+  padding: 5px;
+  border: 1px solid #ddd;
+  font-family: monospace;
+}


### PR DESCRIPTION
Add Icons and colours to the Messages. Colours and icons are based on bootstrap defaults.

Todo: Remove the inline icons and use FA

![image](https://user-images.githubusercontent.com/680570/28055991-722727bc-666f-11e7-83dc-4b7ac2eaab33.png)

Sorry for the huge screenshot, but taking screenshots on a 4K screen is a bit awkward