### PR TITLE
NEW Add Config proxy showing calls to configuration manifests during a request

### DIFF
--- a/code/Collector/ConfigCollector.php
+++ b/code/Collector/ConfigCollector.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace LeKoala\DebugBar\Collector;
+
+use DebugBar\DataCollector\AssetProvider;
+use DebugBar\DataCollector\DataCollector;
+use DebugBar\DataCollector\Renderable;
+use LeKoala\DebugBar\DebugBar;
+use LeKoala\DebugBar\Proxy\ConfigManifestProxy;
+
+/**
+ * Collects data about the config usage during a SilverStripe request
+ */
+class ConfigCollector extends DataCollector implements Renderable, AssetProvider
+{
+    public function getName()
+    {
+        return 'config';
+    }
+
+    public function collect()
+    {
+        $result = ConfigManifestProxy::getConfigCalls();
+        return [
+            'count' => count($result),
+            'calls' => $result
+        ];
+    }
+
+    public function getWidgets()
+    {
+        $widgets = [
+            'config' => [
+                'icon' => 'gear',
+                'widget' => 'PhpDebugBar.Widgets.ConfigWidget',
+                'map' => 'config.calls',
+                'default' => '{}'
+            ]
+        ];
+
+        if (count(ConfigManifestProxy::getConfigCalls()) > 0) {
+            $widgets['config:badge'] = [
+                'map' => 'config.count',
+                'default' => 0
+            ];
+        }
+
+        return $widgets;
+    }
+
+    public function getAssets()
+    {
+        $name = $this->getName();
+
+        return [
+            'base_path' => '/' . DEBUGBAR_DIR . '/javascript',
+            'base_url' => DEBUGBAR_DIR . '/javascript',
+            'css' => $name . '/widget.css',
+            'js' => $name . '/widget.js'
+        ];
+    }
+}

--- a/code/Collector/SilverStripeCollector.php
+++ b/code/Collector/SilverStripeCollector.php
@@ -220,7 +220,7 @@ class SilverStripeCollector extends DataCollector implements Renderable, AssetPr
                 "map" => "$name.parameters",
                 "default" => "{}"
             ),
-            "config" => array(
+            "SiteConfig" => array(
                 "icon" => "gear",
                 "widget" => "PhpDebugBar.Widgets.VariableListWidget",
                 "map" => "$name.config",

--- a/code/Proxy/ConfigManifestProxy.php
+++ b/code/Proxy/ConfigManifestProxy.php
@@ -17,7 +17,7 @@ class ConfigManifestProxy extends CachedConfigCollection
     protected static $configCalls = [];
 
     /**
-     * @param ConfigCollectionInterface $parent
+     * @param CachedConfigCollection $parent
      */
     public function __construct(CachedConfigCollection $parent)
     {

--- a/code/Proxy/ConfigManifestProxy.php
+++ b/code/Proxy/ConfigManifestProxy.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace LeKoala\DebugBar\Proxy;
+
+use SilverStripe\Config\Collections\CachedConfigCollection;
+
+class ConfigManifestProxy extends CachedConfigCollection
+{
+    /**
+     * @var CachedConfigCollection
+     */
+    protected $parent;
+
+    /**
+     * @var array
+     */
+    protected static $configCalls = [];
+
+    /**
+     * @param ConfigCollectionInterface $parent
+     */
+    public function __construct(CachedConfigCollection $parent)
+    {
+        $this->parent = $parent;
+
+        $this->collection = $this->parent->getCollection();
+        $this->cache = $this->parent->getCache();
+        $this->flush = $this->parent->getFlush();
+        $this->collectionCreator = $this->parent->getCollectionCreator();
+    }
+
+    /**
+     * Monitor calls made to get configuration during a request
+     *
+     * {@inheritDoc}
+     */
+    public function get($class, $name = null, $excludeMiddleware = 0)
+    {
+        $result = parent::get($class, $name, $excludeMiddleware);
+
+        if (!isset(self::$configCalls[$class][$name])) {
+            self::$configCalls[$class][$name] = [
+                'calls' => 0,
+                'result' => null
+            ];
+        }
+        self::$configCalls[$class][$name]['calls']++;
+        self::$configCalls[$class][$name]['result'] = $result;
+
+        return $result;
+    }
+
+    /**
+     * Return a lsit of all config calls made during the request, including how many times they were called
+     * and the result
+     *
+     * @return array
+     */
+    public static function getConfigCalls()
+    {
+        return self::$configCalls;
+    }
+}

--- a/code/Proxy/ConfigManifestProxy.php
+++ b/code/Proxy/ConfigManifestProxy.php
@@ -51,7 +51,7 @@ class ConfigManifestProxy extends CachedConfigCollection
     }
 
     /**
-     * Return a lsit of all config calls made during the request, including how many times they were called
+     * Return a list of all config calls made during the request, including how many times they were called
      * and the result
      *
      * @return array

--- a/javascript/config/widget.css
+++ b/javascript/config/widget.css
@@ -1,0 +1,42 @@
+.phpdebugbar .phpdebugbar-widgets-config {
+    font-family: monospace;
+}
+
+.phpdebugbar-widgets-config .phpdebugbar-widgets-container {
+    padding: 8px 8px 8px 16px;
+}
+
+.phpdebugbar-widgets-config .phpdebugbar-widgets-container:hover {
+    background-color: #fafafa;
+}
+
+.phpdebugbar-widgets-config .phpdebugbar-widgets-container:first-child {
+    margin-top: 8px;
+}
+
+.phpdebugbar-widgets-config .phpdebugbar-widgets-item {
+    padding: 8px;
+    border-bottom: 1px solid #eee;
+}
+
+.phpdebugbar-widgets-config .phpdebugbar-widgets-classname {
+    text-decoration: underline;
+}
+
+.phpdebugbar-widgets-config .phpdebugbar-widgets-value {
+    background-color: #fff;
+    border: 1px solid #ddd;
+    margin-top: 8px;
+    padding: 7px;
+}
+
+.phpdebugbar-widgets-config .phpdebugbar-badge {
+    margin-left: 5px;
+    font-size: 11px;
+    line-height: 14px;
+    padding: 1px 7px;
+    background: #005A92;
+    border-radius: 4px;
+    color: #fff;
+    float: right;
+}

--- a/javascript/config/widget.js
+++ b/javascript/config/widget.js
@@ -1,0 +1,62 @@
+(function ($) {
+    var csscls = PhpDebugBar.utils.makecsscls('phpdebugbar-widgets-');
+
+    /**
+     * Widget for displaying a formatted view of config calls and results for a request
+     */
+    var ConfigWidget = PhpDebugBar.Widgets.ConfigWidget = PhpDebugBar.Widget.extend({
+        className: csscls('config'),
+        tagName: 'ul',
+
+        render: function() {
+            this.bindAttr(['data'], function() {
+                this.$el.empty();
+                if (!this.has('data')) {
+                    return;
+                }
+
+                var self = this;
+                $.each(this.get('data'), function(className, args) {
+                    var listItem = $('<li />').addClass(csscls('item'));
+
+                    $('<a />')
+                        .addClass(csscls('classname'))
+                        .html(className)
+                        .appendTo(listItem)
+                        .on('click', function(e) {
+                            e.preventDefault();
+                            $(this).parent('li').children('ul').toggle();
+                        });
+
+                    var keysList = $('<ul />')
+                        .addClass(csscls('keyslist'))
+                        .attr('style', 'display: none')
+                        .appendTo(listItem);
+
+                    $.each(args, function(key, result) {
+                        var heading = key;
+                        if (parseInt(result.calls) > 1) {
+                            heading += ' <span class="phpdebugbar-badge">' + result.calls + '</span>';
+                        }
+
+                        var container = $('<div />').addClass(csscls('container'));
+
+                        $('<h4 />')
+                            .addClass(csscls('key'))
+                            .html(heading)
+                            .appendTo(container);
+
+                        $('<pre />')
+                            .addClass(csscls('value'))
+                            .html('<code>' + JSON.stringify(result.result, null, 2) + '</code>')
+                            .appendTo(container);
+
+                        container.appendTo(keysList);
+                    });
+
+                    listItem.appendTo(self.$el);
+                });
+            });
+        }
+    });
+})(PhpDebugBar.$);

--- a/tests/Collector/SilverStripeCollectorTest.php
+++ b/tests/Collector/SilverStripeCollectorTest.php
@@ -142,7 +142,7 @@ class SilverStripeCollectorTest extends SapphireTest
                 'map' => 'silverstripe.parameters',
                 'default' => '{}',
             ),
-            'config' => array(
+            'SiteConfig' => array(
                 'icon' => 'gear',
                 'widget' => 'PhpDebugBar.Widgets.VariableListWidget',
                 'map' => 'silverstripe.config',

--- a/tests/Proxy/ConfigManifestProxyTest.php
+++ b/tests/Proxy/ConfigManifestProxyTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace LeKoala\DebugBar\Test\Proxy;
+
+use LeKoala\DebugBar\DebugBar;
+use LeKoala\DebugBar\Proxy\ConfigManifestProxy;
+use LeKoala\DebugBar\Proxy\TemplateParserProxy;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Core\Kernel;
+
+class ConfigManifestProxyTest extends SapphireTest
+{
+    protected function setUp()
+    {
+        DebugBar::initDebugBar();
+
+        parent::setUp();
+
+        // Clear out any extra config manifests
+        /** @var SilverStripe\Core\Config\ConfigLoader $configLoader */
+        $configLoader = Injector::inst()->get(Kernel::class)->getConfigLoader();
+
+        while ($configLoader->countManifests() > 1) {
+            if ($configLoader->getManifest() instanceof ConfigManifestProxy) {
+                continue;
+            }
+            $configLoader->popManifest();
+        }
+    }
+
+    public function testProxyIsPushedToLoader()
+    {
+        $configLoader = Injector::inst()->get(Kernel::class)->getConfigLoader();
+        $this->assertInstanceOf(ConfigManifestProxy::class, $configLoader->getManifest());
+    }
+
+    public function testGetCallsAreCaptured()
+    {
+        Config::inst()->get(TemplateParserProxy::class, 'cached');
+        $result = Injector::inst()->get(Kernel::class)->getConfigLoader()->getManifest()->getConfigCalls();
+        $this->assertArrayHasKey(TemplateParserProxy::class, $result);
+        $this->assertArrayHasKey('cached', $result[TemplateParserProxy::class]);
+        $this->assertEquals(1, $result[TemplateParserProxy::class]['cached']['calls']);
+
+        Config::inst()->get(TemplateParserProxy::class, 'cached');
+        Config::inst()->get(TemplateParserProxy::class, 'cached');
+        Config::inst()->get(TemplateParserProxy::class, 'cached');
+        $result = Injector::inst()->get(Kernel::class)->getConfigLoader()->getManifest()->getConfigCalls();
+        $this->assertEquals(4, $result[TemplateParserProxy::class]['cached']['calls']);
+    }
+}


### PR DESCRIPTION
This pull request removes the SiteConfig listing from the Config tab and adds a list of config calls that were made during a page request. It will show duplicated calls with a badge.

I expect this approach to be iterated on, but this is a first pass.