### PR TITLE
NEW Remove opacity from tooltip to meet WCAG AA standards

### DIFF
--- a/assets/debugbar.css
+++ b/assets/debugbar.css
@@ -231,7 +231,6 @@ a.phpdebugbar-open-btn {
     position: absolute;
     top: -30px;
     background: #efefef;
-    opacity: .7;
     border: 1px solid #ccc;
     color: #555;
     font-size: 11px;


### PR DESCRIPTION
Resolves #64

Removed to meet WCAG AA color contrast standards and also to help with readability when there is text (on the main site) behind the tooltip.