### PR TITLE
FIX Remove NullHandler logger override. DebugBar will only display debug and info messages.

### DIFF
--- a/_config/debugbar.yml
+++ b/_config/debugbar.yml
@@ -41,9 +41,6 @@ SilverStripe\Core\Injector\Injector:
     class: LeKoala\DebugBar\Proxy\TemplateParserProxy
   DebugBarMiddleware:
     class: LeKoala\DebugBar\Middleware\DebugBarMiddleware
-  # Disable the default SilverStripe log handler which sends everything to the browser
-  Monolog\Handler\HandlerInterface:
-    class: Monolog\Handler\NullHandler
   SilverStripe\Control\Director:
     properties:
       Middlewares:


### PR DESCRIPTION
Framework will handle what it decides to handle with the HTTP output handler, and whatever is not handled by it will be sent to the DebugBar messages tab. This means the messages tab is unlikely to ever see notices or higher (warnings/errors), but that this module does not interfere with core error handling.

At the moment errors, critical, emergency etc thrown during execution will result in a white screen with no useful information, since the core error handler was disabled.

Resolves #72