### PR TITLE
FIX Allow enabled_in_admin to work when run in a subfolder

### DIFF
--- a/code/DebugBar.php
+++ b/code/DebugBar.php
@@ -21,6 +21,7 @@ use Psr\Log\LoggerInterface;
 use Monolog\Logger;
 use ReflectionObject;
 use SilverStripe\Admin\LeftAndMain;
+use SilverStripe\Admin\AdminRootController;
 use SilverStripe\Config\Collections\CachedConfigCollection;
 use SilverStripe\Control\Director;
 use SilverStripe\Control\HTTPRequest;
@@ -338,7 +339,10 @@ class DebugBar
 
     public static function isAdminUrl()
     {
-        return strpos(self::getRequestUrl(), '/admin/') === 0;
+        $baseUrl = rtrim(BASE_URL, '/');
+        $adminUrl = AdminRootController::config()->get('url_base');
+
+        return strpos(self::getRequestUrl(), $baseUrl . '/' . $adminUrl . '/') === 0;
     }
 
     public static function isAdminController()


### PR DESCRIPTION
Fix for #68 in the 2.x version (SS4 compatible). The same logic (minus the configurable admin URL) could be backported to 1.x for SS3 compat.