### PR TITLE
FIX Reduce warning to info level to prevent user_error from breaking layout

### DIFF
--- a/code/Collector/DatabaseCollector.php
+++ b/code/Collector/DatabaseCollector.php
@@ -43,7 +43,7 @@ class DatabaseCollector extends DataCollector implements Renderable, AssetProvid
         if ($dbQueryWarningLevel && $data['nb_statements'] > $dbQueryWarningLevel) {
             $helpLink = DebugBar::config()->performance_guide_link;
             Injector::inst()->get(LoggerInterface::class)
-                ->addWarning(
+                ->info(
                     'This page ran more than ' . $dbQueryWarningLevel . ' database queries. You could reduce this by '
                     . 'implementing caching. For more information, <a href="' . $helpLink . '" target="_blank">'
                     . 'click here.</a>'

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,7 +6,7 @@
 
     <filter>
         <whitelist addUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">.</directory>
+            <directory suffix=".php">code/</directory>
             <exclude>
                 <directory suffix=".php">tests/</directory>
             </exclude>


### PR DESCRIPTION
We should only be using info and debug levels to prevent the frontend/CMS layouts from being affected by higher levels being displayed.

Also fixes the coverage whitelist to only look at `code/`