### PR TITLE
FIX Update unit test class 

### DIFF
--- a/code/DebugBar.php
+++ b/code/DebugBar.php
@@ -349,7 +349,8 @@ class DebugBar
      *
      * @return array
      */
-    public static function disabledCriteria() {
+    public static function disabledCriteria()
+    {
         $reasons = array();
         if (!Director::isDev()) {
             $reasons[] = 'Not in dev mode';
@@ -372,7 +373,7 @@ class DebugBar
         if (self::isAdminUrl() && !self::config()->get('enabled_in_admin')) {
             $reasons[] = 'In admin';
         }
-        if(isset($_GET['CMSPreview'])) {
+        if (isset($_GET['CMSPreview'])) {
             $reasons[] = 'CMS Preview';
         }
         return $reasons;
@@ -388,7 +389,7 @@ class DebugBar
     public static function whyDisabled()
     {
         $reasons = self::disabledCriteria();
-        if(!empty($reasons)) {
+        if (!empty($reasons)) {
             return $reasons[0];
         }
         return "I don't know why";

--- a/code/Extension/ProxyDBExtension.php
+++ b/code/Extension/ProxyDBExtension.php
@@ -243,5 +243,4 @@ class ProxyDBExtension extends Extension
         }
         return implode(' > ', $sources);
     }
-
 }

--- a/tests/Extension/ProxyDBExtensionTest.php
+++ b/tests/Extension/ProxyDBExtensionTest.php
@@ -25,7 +25,8 @@ class ProxyDBExtensionTest extends SapphireTest
         $this->conn = DB::get_conn();
     }
 
-    public function testQueriesAreCollected() {
+    public function testQueriesAreCollected()
+    {
         $this->assertNotEmpty(ProxyDBExtension::getQueries());
     }
 }

--- a/tests/Proxy/ConfigManifestProxyTest.php
+++ b/tests/Proxy/ConfigManifestProxyTest.php
@@ -2,13 +2,14 @@
 
 namespace LeKoala\DebugBar\Test\Proxy;
 
+use SilverStripe\Core\Config\ConfigLoader;
 use SilverStripe\Core\Kernel;
 use LeKoala\DebugBar\DebugBar;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Injector\Injector;
 use LeKoala\DebugBar\Proxy\ConfigManifestProxy;
-use LeKoala\DebugBar\Proxy\TemplateParserProxy;
+use LeKoala\DebugBar\Proxy\SSViewerProxy;
 
 class ConfigManifestProxyTest extends SapphireTest
 {
@@ -18,43 +19,29 @@ class ConfigManifestProxyTest extends SapphireTest
 
         DebugBar::initDebugBar();
 
-        // Clear out any extra config manifests
-        /** @var SilverStripe\Core\Config\ConfigLoader $configLoader */
+        /** @var ConfigLoader $configLoader */
         $configLoader = Injector::inst()->get(Kernel::class)->getConfigLoader();
 
-        $found = false;
-        while ($configLoader->countManifests() > 1) {
-            if ($configLoader->getManifest() instanceof ConfigManifestProxy) {
-                $found = true;
-                continue;
-            }
-            $configLoader->popManifest();
-        }
-        if (!$found) {
+        // Check top level manifest is our proxy
+        if (!($configLoader->getManifest() instanceof ConfigManifestProxy)) {
             $this->markTestSkipped("ConfigManifestProxy is not initialized");
         }
-    }
-
-    public function testProxyIsPushedToLoader()
-    {
-        $configLoader = Injector::inst()->get(Kernel::class)->getConfigLoader();
-        $this->assertInstanceOf(ConfigManifestProxy::class, $configLoader->getManifest());
     }
 
     public function testGetCallsAreCaptured()
     {
         $manifest = Injector::inst()->get(Kernel::class)->getConfigLoader()->getManifest();
 
-        Config::inst()->get(TemplateParserProxy::class, 'cached');
+        Config::inst()->get(SSViewerProxy::class, 'cached');
         $result = $manifest->getConfigCalls();
-        $this->assertArrayHasKey(TemplateParserProxy::class, $result);
-        $this->assertArrayHasKey('cached', $result[TemplateParserProxy::class]);
-        $this->assertEquals(1, $result[TemplateParserProxy::class]['cached']['calls']);
+        $this->assertArrayHasKey(SSViewerProxy::class, $result);
+        $this->assertArrayHasKey('cached', $result[SSViewerProxy::class]);
+        $this->assertEquals(1, $result[SSViewerProxy::class]['cached']['calls']);
 
-        Config::inst()->get(TemplateParserProxy::class, 'cached');
-        Config::inst()->get(TemplateParserProxy::class, 'cached');
-        Config::inst()->get(TemplateParserProxy::class, 'cached');
+        Config::inst()->get(SSViewerProxy::class, 'cached');
+        Config::inst()->get(SSViewerProxy::class, 'cached');
+        Config::inst()->get(SSViewerProxy::class, 'cached');
         $result = $manifest->getConfigCalls();
-        $this->assertEquals(4, $result[TemplateParserProxy::class]['cached']['calls']);
+        $this->assertEquals(4, $result[SSViewerProxy::class]['cached']['calls']);
     }
 }

--- a/tests/Proxy/SSViewerProxyTest.php
+++ b/tests/Proxy/SSViewerProxyTest.php
@@ -31,7 +31,7 @@ class SSViewerProxyTest extends FunctionalTest
         $textfieldPath = str_replace('/', DIRECTORY_SEPARATOR, $textfieldPath);
 
         $this->assertNotEmpty($templates);
-        $this->assertContains($formPath,$templates);
-        $this->assertContains($textfieldPath,$templates);
+        $this->assertContains($formPath, $templates);
+        $this->assertContains($textfieldPath, $templates);
     }
 }


### PR DESCRIPTION
Removes the infinite loop from the setUp method in ConfigManifestProxyTest and modifies the method to only check the last class manifest.
One unnecessary test is removed and the class names in testGetCallsAreCaptured() are updated.

Resolves #93 - The actual DBProxy changes were made by @lekoala. In conjunction with https://github.com/lekoala/silverstripe-debugbar/commit/442bc436b9bef7c04533b2d70ec72c85ff6e86f0 this pull request resolves the Travis and Scrutinizer issues.