### PR TITLE
Session::getAll() may return `null`

### DIFF
--- a/code/Collector/SilverStripeCollector.php
+++ b/code/Collector/SilverStripeCollector.php
@@ -98,6 +98,11 @@ class SilverStripeCollector extends DataCollector implements Renderable, AssetPr
     public static function getSessionData()
     {
         $data = DebugBar::getRequest()->getSession()->getAll();
+
+        if (empty($data)) {
+            return [];
+        }
+
         $filtered = [];
 
         // Filter not useful data


### PR DESCRIPTION
I experienced an error when i cleared the website cookie: in this case `SilverStripe\Control\Session::getAll()` is returning `null` and not an empty array (which would be a nice suggestion to ss-repo), thus leading to a foreach-loop error.