### PR TITLE
FIX ensure debugbar is run after app config

### DIFF
--- a/_config/debugbar.yml
+++ b/_config/debugbar.yml
@@ -1,6 +1,8 @@
 ---
 Name: debugbar
-Before: 'mysite'
+Before:
+  - 'mysite'
+  - 'app'
 After:
   - 'framework'
 Only:


### PR DESCRIPTION
Now that SilverStripe 4 recommends the `app` folder structure instead of `mysite`, debugbar should cater for both cases to not trip people up when overriding config values.