### PR TITLE
NEW: PHP 7.2 support in debugbar 1.2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,16 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.1
+  - 7.2
 
 env:
-  - DB=MYSQL CORE_RELEASE=3.5
+  - DB=MYSQL CORE_RELEASE=3.7
 
 matrix:
   include:
     - php: 7.1
-      env: DB=MYSQL CORE_RELEASE=3.6
-    - php: 7.1
-      env: DB=MYSQL CORE_RELEASE=3 COVERAGE="--coverage-clover=coverage.xml"
+      env: DB=MYSQL CORE_RELEASE=3.7 COVERAGE="--coverage-clover=coverage.xml"
 
 before_script:
   - composer self-update || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ language: php
 dist: precise
 
 php:
-  - 5.3
-  - 5.4
   - 5.5
   - 5.6
   - 7.1

--- a/code/DebugBar.php
+++ b/code/DebugBar.php
@@ -3,7 +3,7 @@
 /**
  * A simple helper
  */
-class DebugBar extends Object
+class DebugBar extends SS_Object
 {
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.5",
         "silverstripe/framework": "~3.7",
         "silverstripe/siteconfig": "~3.7",
         "maximebf/debugbar": "^1.13"

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "silverstripe/framework": "~3.2",
-        "silverstripe/siteconfig": "~3.2",
+        "silverstripe/framework": "~3.7",
+        "silverstripe/siteconfig": "~3.7",
         "maximebf/debugbar": "^1.13"
     },
     "extra": {


### PR DESCRIPTION
This necessitates dropping support for SilverStripe < 3.7

If this gets merged I'd recommend creating a 1.2 branch a 1.2.0-beta1 release