### PR TITLE
FIX DebugBar now trims "extra" section of PHP_VERSION from PHP version information for readability

### DIFF
--- a/code/Collector/PhpInfoCollector.php
+++ b/code/Collector/PhpInfoCollector.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace LeKoala\DebugBar\Collector;
+
+/**
+ * Extends the default PhpInfoCollector to trim long PHP version numbers
+ */
+class PhpInfoCollector extends \DebugBar\DataCollector\PhpInfoCollector
+{
+    public function collect()
+    {
+        $metrics = parent::collect();
+        $metrics['version'] = $this->trimVersion($metrics['version']);
+        return $metrics;
+    }
+
+    /**
+     * Given a PHP_VERSION constant value, trim any "extra" meta information from the end, returning the major, minor
+     * and patch release of the version. Will fall back to returning the input if the matching fails.
+     *
+     * @param string $version
+     * @return string
+     */
+    protected function trimVersion($version)
+    {
+        preg_match('/^(\d+\.\d+\.\d+)/', $version, $matches);
+        return !empty($matches[0]) ? $matches[0] : $version;
+    }
+}

--- a/code/Collector/PhpInfoCollector.php
+++ b/code/Collector/PhpInfoCollector.php
@@ -23,7 +23,7 @@ class PhpInfoCollector extends \DebugBar\DataCollector\PhpInfoCollector
      */
     protected function trimVersion($version)
     {
-        preg_match('/^(\d+\.\d+\.\d+)/', $version, $matches);
+        preg_match('/^\d+\.\d+\.\d+/', $version, $matches);
         return !empty($matches[0]) ? $matches[0] : $version;
     }
 }

--- a/tests/Collector/PhpInfoCollectorTest.php
+++ b/tests/Collector/PhpInfoCollectorTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace LeKoala\DebugBar\Test\Collector;
+
+use LeKoala\DebugBar\Collector\PhpInfoCollector;
+use PHPUnit_Framework_TestCase;
+use ReflectionClass;
+
+class PhpInfoCollectorTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Note: testing with reflection since it's tidier than moving parent::collect() into its own method just
+     * so we can mock it.
+     *
+     * @dataProvider longPhpVersionProvider
+     * @param string $phpVersion
+     * @param string $expected
+     * @throws \ReflectionException
+     */
+    public function testTrimLongPhpVersionNumbers($phpVersion, $expected)
+    {
+        $reflection = new ReflectionClass(PhpInfoCollector::class);
+        $method = $reflection->getMethod('trimVersion');
+        $method->setAccessible(true);
+
+        $collector = new PhpInfoCollector();
+        $result = $method->invokeArgs($collector, [$phpVersion]);
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * @return array[]
+     */
+    public function longPhpVersionProvider()
+    {
+        return [
+            ['5.6.13', '5.6.13'],
+            ['7.3.0', '7.3.0'],
+            ['7.3.0dev', '7.3.0'],
+            ['7.3.0-dev123+00', '7.3.0'],
+            ['7.1.25-1+0~2017093290850938459043.8+jessie~1.gbpebe5d6', '7.1.25'],
+        ];
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/lekoala/silverstripe-debugbar/issues/85