### PR TITLE
Make the requirements more readable

### DIFF
--- a/code/Collector/SilverStripeCollector.php
+++ b/code/Collector/SilverStripeCollector.php
@@ -87,9 +87,17 @@ class SilverStripeCollector extends DataCollector implements Renderable, AssetPr
 
         $output = [];
         foreach ($requirements as $asset => $specs) {
-            $output[] = $asset . ': ' . Convert::raw2json($specs);
+            // Get the filename only
+            $fileNames = explode('/', $asset);
+            $fileName = end($fileNames);
+            $specs['href'] = $asset;
+            $output[$fileName] = json_encode($specs, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
         }
-        return $output;
+
+        return [
+            'list' => $output,
+            'count' => count($requirements)
+        ];
     }
 
     public static function getRequestParameters()
@@ -245,10 +253,14 @@ class SilverStripeCollector extends DataCollector implements Renderable, AssetPr
                 "default" => "{}"
             ),
             "requirements" => array(
-                "icon" => "file-text-o",
-                "widget" => "PhpDebugBar.Widgets.ListWidget",
-                "map" => "$name.requirements",
+                "icon"    => "file-text-o",
+                "widget"  => "PhpDebugBar.Widgets.VariableListWidget",
+                "map"     => "$name.requirements.list",
                 "default" => "{}"
+            ),
+            "requirements:badge" => array(
+                "map"     => "$name.requirements.count",
+                "default" => 0
             ),
             "middlewares" => array(
                 "icon" => "file-text-o",

--- a/tests/Collector/SilverStripeCollectorTest.php
+++ b/tests/Collector/SilverStripeCollectorTest.php
@@ -49,7 +49,7 @@ class SilverStripeCollectorTest extends SapphireTest
         // $this->assertContains('Framework', $data['version']);
         $this->assertSame(SiteConfig::class, $data['config']['ClassName']);
         $this->assertSame('User, ADMIN', $data['user']);
-        $this->assertCount(0, $data['requirements']);
+        $this->assertCount(0, $data['requirements']['list']);
 
         $this->logOut();
 
@@ -62,8 +62,9 @@ class SilverStripeCollectorTest extends SapphireTest
         Requirements::css('debugbar/assets/debugbar.css');
         $data = $this->collector->collect();
         $this->assertArrayHasKey('requirements', $data);
-        $this->assertNotEmpty($data['requirements']);
-        $this->assertContains('assets/debugbar.css', $data['requirements'][0]);
+        $this->assertNotEmpty($data['requirements']['list']);
+        $this->assertGreaterThan(0, $data['requirements']['count']);
+        $this->assertArrayHasKey('debugbar.css', $data['requirements']['list']);
     }
 
     public function testShowRequestParameters()


### PR DESCRIPTION
Strips slashes from the files path to display as an expandable JSON list, much like the Session and Cookies view, to make the output more readable and expandable.