### PR TITLE
Update SSViewerProxy.php

### DIFF
--- a/code/Proxy/SSViewerProxy.php
+++ b/code/Proxy/SSViewerProxy.php
@@ -33,6 +33,9 @@ class SSViewerProxy extends SSViewer
      */
     public function process($item, $arguments = null, $inheritedScope = null)
     {
+        if (DebugBar::isDisabled()) {
+            return parent::process($item, $arguments, $inheritedScope);
+        }
         $templateName = self::normalizeTemplateName($this->chosen);
         self::trackTemplateUsed($templateName);
 


### PR DESCRIPTION
Fixes an error that gets raised when the debugbar is disabled:

```[Emergency] Uncaught Error: Call to a member function getCollector() on bool```