### PR TITLE
Fix PHP 8.1 deprecation message (passing null to strlen())

### DIFF
--- a/code/Extension/ProxyDBExtension.php
+++ b/code/Extension/ProxyDBExtension.php
@@ -107,10 +107,12 @@ class ProxyDBExtension extends Extension
             $matches = null;
             preg_match_all('/SELECT(.+?) FROM/is', $sql, $matches);
             $select = empty($matches[1]) ? null : trim($matches[1][0]);
-            if (strlen($select) > 100) {
-                $shortsql = str_replace($select, '"ClickToShowFields"', $sql);
-            } else {
-                $select = null;
+            if($select !== null) {
+                if (strlen($select) > 100) {
+                    $shortsql = str_replace($select, '"ClickToShowFields"', $sql);
+                } else {
+                    $select = null;
+                }
             }
 
             self::$queries[] = array(


### PR DESCRIPTION
With SS 4.11 there is official support for PHP 8.1, but there is a deprecation message coming from ProxyDBExtension.php

`[Deprecated] strlen(): Passing null to parameter #1 ($string) of type string is deprecated`

The problem being that $select can be passed with null value to strlen($select) [here](https://github.com/lekoala/silverstripe-debugbar/blob/master/code/Extension/ProxyDBExtension.php#L109)

```php
$select = empty($matches[1]) ? null : trim($matches[1][0]);
            if (strlen($select) > 100) {
```

This pull request simply checks if the value of $select is null before processing the if condition.