### PR TITLE
Deprecated trim() fix

### DIFF
--- a/code/Aspects/CacheAfterCallAspect.php
+++ b/code/Aspects/CacheAfterCallAspect.php
@@ -16,7 +16,7 @@ class CacheAfterCallAspect implements AfterCallAspect
     public function afterCall($proxied, $method, $args, $result)
     {
         $message = (empty($result)) ? "Missed: {$args[0]}" : "Hit: {$args[0]}";
-        $result = preg_replace('/\s+/', ' ', trim($result));
+        $result = preg_replace('/\s+/', ' ', trim($result) ?? '');
         $result = Convert::raw2att($result);
         PartialCacheCollector::addTemplateCache(
             $message,


### PR DESCRIPTION
I was doing a SilverStripe upgrade with PHP 8.1 and noticed this deprecation error: 
[Deprecated] trim(): Passing null to parameter #1 ($string) of type string is deprecated

A proposed fix for this is to add a null coalescing operator to fallback to an empty string