### PR TITLE
fix php 8.1 deprecation warning

### DIFF
--- a/code/Aspects/CacheAfterCallAspect.php
+++ b/code/Aspects/CacheAfterCallAspect.php
@@ -16,7 +16,7 @@ class CacheAfterCallAspect implements AfterCallAspect
     public function afterCall($proxied, $method, $args, $result)
     {
         $message = (empty($result)) ? "Missed: {$args[0]}" : "Hit: {$args[0]}";
-        $result = preg_replace('/\s+/', ' ', trim($result) ?? '');
+        $result = preg_replace('/\s+/', ' ', trim($result ?? ''));
         $result = Convert::raw2att($result);
         PartialCacheCollector::addTemplateCache(
             $message,


### PR DESCRIPTION
As per https://github.com/lekoala/silverstripe-debugbar/issues/136 there is still a deprecation warning when using php 8.1 as trim() wants a string.