### PR TITLE
MNT Fix CI github workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,13 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+  # Every Friday at 10:20am UTC
+  schedule:
+    - cron: '20 10 * * 5'
 
 jobs:
   ci:
     name: CI
-    uses: silverstripe/gha-ci/.github/workflows/ci.yml@v2
+    # Only run cron on the silverstripe account
+    if: (github.event_name == 'schedule' && github.repository_owner == 'lekoala') || (github.event_name != 'schedule')
+    uses: silverstripe/gha-ci/.github/workflows/ci.yml@v1


### PR DESCRIPTION
Fixes the syntax and adds a cron.

The cron allows us to validate if there are any regressions caused by upstream dependencies even if no changes are made to this module.

## Parent issue
- https://github.com/lekoala/silverstripe-debugbar/issues/141