### PR TITLE
ENH Ensure deprecation notices are collected

### DIFF
--- a/code/DebugBar.php
+++ b/code/DebugBar.php
@@ -46,6 +46,7 @@ use LeKoala\DebugBar\Collector\PartialCacheCollector;
 use LeKoala\DebugBar\Collector\SilverStripeCollector;
 use SilverStripe\Config\Collections\DeltaConfigCollection;
 use SilverStripe\Config\Collections\CachedConfigCollection;
+use SilverStripe\Dev\Deprecation;
 
 /**
  * A simple helper
@@ -400,6 +401,13 @@ class DebugBar
         $initialize = true;
         if (Director::is_ajax()) {
             $initialize = false;
+        }
+
+        // Normally deprecation notices are output in a shutdown function, which runs well after debugbar has rendered.
+        // This ensures the deprecation notices which have been noted up to this point are logged out and collected by
+        // the MonologCollector.
+        if (method_exists(Deprecation::class, 'outputNotices')) {
+            Deprecation::outputNotices();
         }
 
         $script = self::$renderer->render($initialize);


### PR DESCRIPTION
This might work without https://github.com/silverstripe/silverstripe-framework/pull/10697 but is intended to go hand-in-hand with it.

I had a go at writing a test for this but given there's _no_ tests which actually check that things are included in the debugbar as expected I wasn't sure how to go about it. I had to cheat a little to get it to render at all in the test and when it did, all its tabs were empty.

## Parent issue
- https://github.com/silverstripe/silverstripe-framework/issues/10608