### PR TITLE
removal of beta tag for cms 5 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "silverstripe/framework": "^5",
         "maximebf/debugbar": "^1.18",
         "jdorn/sql-formatter": "1.3.x-dev",
-        "tractorcow/silverstripe-proxy-db": "2.0.0-beta1"
+        "tractorcow/silverstripe-proxy-db": "2.0.0"
     },
     "require-dev": {
         "silverstripe/siteconfig": "^5",


### PR DESCRIPTION

`2.0.0` stable tag now [tagged](https://github.com/tractorcow/silverstripe-proxy-db/issues/7), this is just an update to use it :)
Tested locally on `5.1.0`.