### PR TITLE
Ensure templateName is a valid value

### DIFF
--- a/code/Proxy/SSViewerProxy.php
+++ b/code/Proxy/SSViewerProxy.php
@@ -141,6 +141,10 @@ class SSViewerProxy extends SSViewer
      */
     protected static function normalizeTemplateName($templateName)
     {
+        // Fallback for if the templateName is not a string or array (or anything, really)
+        if (!$templateName) {
+            $templateName = '';
+        }
         return str_ireplace(BASE_PATH, '', $templateName);
     }
 }


### PR DESCRIPTION
Calling `str_ireplace()` with null as `templateName`, causes a deprecation warning. Ensuring it's an empty string if it's null/false/etc. ensures this deprecation won't happen. Since passing an array to `str_ireplace()` as third parameter _is valid_, simply calling `(string)$templateName` would not suffice.