### PR TITLE
Removal of CMS 6 dev-pull branch dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "silverstripe/framework": "^6",
         "php-debugbar/php-debugbar": "^2",
         "doctrine/sql-formatter": "^1.5",
-        "tractorcow/silverstripe-proxy-db": "dev-pulls/cms6-support"
+        "tractorcow/silverstripe-proxy-db": "^3"
     },
     "require-dev": {
         "silverstripe/siteconfig": "^6",
@@ -28,12 +28,6 @@
         "phpunit/phpunit": "^11.5",
         "squizlabs/php_codesniffer": "^3"
     },
-    "repositories": [
-        {
-            "type": "git",
-            "url": "https://github.com/silverstripeltd/silverstripe-proxy-db.git"
-        }
-    ],
     "extra": {
         "branch-alias": {
             "dev-master": "3.x-dev"


### PR DESCRIPTION
CMS 6 support for https://github.com/tractorcow/silverstripe-proxy-db/pull/9 was merged thus update to remove and use release tag `3.0.0`.